### PR TITLE
Unit conversion not in-place

### DIFF
--- a/pdtable/proxy.py
+++ b/pdtable/proxy.py
@@ -290,15 +290,25 @@ class Table:
         return False
 
     def convert_units(self, to: ColumnUnitDispatcher, converter: UnitConverter) -> "Table":
-        """Applies unit conversion to columns, modifying table in-place
+        """Returns a new table with units converted as specified.
+
+        Returns a new table with converted units. The desired new unit are specified by
+        column.
+
+        How to do a conversion from unit X to unit Y is determined by the supplied unit
+        converter.
+
+        The converter is also responsible for deciding what unit is considered the
+        "base unit" of unit X.  Depending on your application and favourite unit system, the base
+        unit of 'mm' could be 'm', 'foot', 'furlong', or some other unit of dimension length.
 
         Args:
             to:
-                Specifies what units to convert which columns to. Can be:
+                Specifies to what units to convert which columns. Can be:
                 - 'base': Converts all columns to their respective base units. Columns with
                   inconvertible unit indicators are skipped.
-                - 'origin': Converts all columns to their respective origin units. Columns with
-                  inconvertible unit indicators are skipped.
+                - 'origin': (not yet implemented!) Converts all columns to their respective origin
+                  units. Columns with inconvertible unit indicators are skipped.
                 - A dictionary of {column_name: target_unit}. Superfluous column names are ignored.
                 - A callable with one argument: column name. Must return the target unit, or None
                   if no unit conversion is to be done.
@@ -331,7 +341,7 @@ class Table:
                         would return "millimeter".
 
         Returns:
-            None
+            A new Table with converted units.
 
         """
 

--- a/pdtable/proxy.py
+++ b/pdtable/proxy.py
@@ -289,7 +289,7 @@ class Table:
             # is just a number, and no such distinction should be made between data types.
         return False
 
-    def convert_units(self, to: ColumnUnitDispatcher, converter: UnitConverter):
+    def convert_units(self, to: ColumnUnitDispatcher, converter: UnitConverter) -> "Table":
         """Applies unit conversion to columns, modifying table in-place
 
         Args:
@@ -334,8 +334,11 @@ class Table:
             None
 
         """
+
+        new_table = Table(self.df.copy())
+
         if to == "origin":
-            for col in self.column_proxies:
+            for col in new_table.column_proxies:
                 if col.unit in INCONVERTIBLE_UNIT_INDICATORS:
                     # Skip this column
                     continue
@@ -343,7 +346,7 @@ class Table:
 
         elif to == "base":
             # Convert all columns to their respective base units
-            for col in self.column_proxies:
+            for col in new_table.column_proxies:
                 if col.unit in INCONVERTIBLE_UNIT_INDICATORS:
                     # Skip this column
                     continue
@@ -354,24 +357,26 @@ class Table:
                 raise ValueError(
                     "Unequal number of columns and of 'to' units", len(self.column_proxies), len(to)
                 )
-            for col, to_unit in zip(self.column_proxies, to):
+            for col, to_unit in zip(new_table.column_proxies, to):
                 if to_unit is not None:
                     col.convert_units(to_unit, converter)
 
         elif isinstance(to, Dict):
-            for column in self.column_proxies:
+            for column in new_table.column_proxies:
                 to_unit = to.get(column.name)
                 if to_unit is not None:
                     column.convert_units(to[column.name], converter)
 
         elif isinstance(to, Callable):
-            for column in self.column_proxies:
+            for column in new_table.column_proxies:
                 to_unit = to(column.name)
                 if to_unit is not None:
                     column.convert_units(to_unit, converter)
 
         else:
             raise TypeError("Column unit dispatcher of unexpected type.", type(to), to)
+
+        return new_table
 
 
 def _equal_or_same(a, b):

--- a/pdtable/test/test_units.py
+++ b/pdtable/test/test_units.py
@@ -112,8 +112,7 @@ def table_cells():
 
 
 def test_convert_units__to_base_units(table_cells, cuc):
-    t = make_table(table_cells)
-    t.convert_units(to="base", converter=cuc)
+    t = make_table(table_cells).convert_units(to="base", converter=cuc)
 
     # Converted to base units
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))
@@ -130,8 +129,7 @@ def test_convert_units__to_base_units(table_cells, cuc):
 
 
 def test_convert_units__list(table_cells, cuc):
-    t = make_table(table_cells)
-    t.convert_units(to=["m", "K", None, None, None], converter=cuc)
+    t = make_table(table_cells).convert_units(to=["m", "K", None, None, None], converter=cuc)
 
     # Conversion done on columns as requested
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))
@@ -145,8 +143,7 @@ def test_convert_units__list(table_cells, cuc):
 
 
 def test_convert_units__dict(table_cells, cuc):
-    t = make_table(table_cells)
-    t.convert_units(to={"diameter": "m", "mean_temp": "K"}, converter=cuc)
+    t = make_table(table_cells).convert_units(to={"diameter": "m", "mean_temp": "K"}, converter=cuc)
 
     # Conversion done on columns as requested
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))
@@ -163,8 +160,7 @@ def test_convert_units__callable(table_cells, cuc):
     def to_units_fun(table_name: str) -> Optional[str]:
         return {"diameter": "m", "mean_temp": "K"}.get(table_name)
 
-    t = make_table(table_cells)
-    t.convert_units(to=to_units_fun, converter=cuc)
+    t = make_table(table_cells).convert_units(to=to_units_fun, converter=cuc)
 
     # Conversion done on columns as requested
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))
@@ -185,6 +181,3 @@ def test_convert_units__fails_on_inconvertible_unit(table_cells, cuc):
     with pytest.raises(UnitConversionNotDefinedError):
         # Attempt to convert units of a text
         t.convert_units(to=[None, None, None, None, "m"], converter=cuc)
-
-
-# TODO deal with NaN values in columns

--- a/pdtable/utils.py
+++ b/pdtable/utils.py
@@ -32,8 +32,11 @@ def normalized_table_generator(
                 )
 
             if to_units is not None:
-                table.convert_units(to=convert_units_to[table.name], converter=unit_converter)
-        yield block_type, block
+                table = table.convert_units(to=to_units, converter=unit_converter)
+            yield block_type, table
+
+        else:
+            yield block_type, block
 
 
 def read_bundle_from_csv(


### PR DESCRIPTION
Now returns a new, fresh table from `Table.convert_units()` instead of doing conversion in place.

```
# old
# t.convert_units(to={"distance": "km"}, converter=pdtable.pint_converter)

# new
t2 = t.convert_units(to={"distance": "km"}, converter=pdtable.pint_converter)
```
`t2` is created as `Table(t.df.copy())`

Good enough?
@JanusWesenberg I'm not sure I see the benefit of completely decoupling `convert_units` from `Table` as you suggested... Seems to me, it's a natural fit as a method, adding no dependencies to `Table` as a class.  
A glass-half-full kind of person could see this as an opportunity to make me see the light :-)