### PR TITLE
Feature/global unit converter

### DIFF
--- a/pdtable/__init__.py
+++ b/pdtable/__init__.py
@@ -12,4 +12,4 @@ from .store import TableBundle, BlockType, BlockIterator
 from .io import ParseFixer
 from .io import read_csv, write_csv
 from .io import read_excel, write_excel
-from .units.converter import pint_converter, DefaultUnitConverter
+from .units.converter import pint_converter, PintUnitConverter

--- a/pdtable/test/test_units.py
+++ b/pdtable/test/test_units.py
@@ -7,7 +7,7 @@ import pytest
 from pint import DimensionalityError, UndefinedUnitError
 from pytest import fixture, raises
 
-from pdtable.units.converter import pint_converter, DefaultUnitConverter
+from pdtable.units.converter import pint_converter, PintUnitConverter
 from ..demo.unit_converter import convert_this
 from ..io.parsers.blocks import make_table
 from ..proxy import UnitConversionNotDefinedError
@@ -66,7 +66,7 @@ def test_default_converter__works():
         pint_converter(1, "quxx")
 
 
-class CustomUnitConverter(DefaultUnitConverter):
+class CustomUnitConverter(PintUnitConverter):
     def __init__(self):
         super().__init__()
 

--- a/pdtable/test/test_units.py
+++ b/pdtable/test/test_units.py
@@ -175,17 +175,17 @@ def test_convert_units__callable(table_cells, cuc):
 
 
 def test_convert_units__using_default_converter(table_cells, cuc):
-    t = make_table(table_cells)
+    t_old_units = make_table(table_cells)
 
     assert pdtable.units.default_converter is None
     with raises(MissingUnitConverterError):
         # No default unit converter was set
-        t.convert_units(to={"diameter": "m", "mean_temp": "K"})
+        t_old_units.convert_units(to={"diameter": "m", "mean_temp": "K"})
 
     # Now set a default converter
     pdtable.units.default_converter = cuc
     # Do conversion; no explicitly specified unit converter; uses default
-    t.convert_units(to={"diameter": "m", "mean_temp": "K"})
+    t = t_old_units.convert_units(to={"diameter": "m", "mean_temp": "K"})
 
     # Conversion done on columns as requested
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))

--- a/pdtable/test/test_units.py
+++ b/pdtable/test/test_units.py
@@ -7,10 +7,11 @@ import pytest
 from pint import DimensionalityError, UndefinedUnitError
 from pytest import fixture, raises
 
+import pdtable
 from pdtable.units.converter import pint_converter, PintUnitConverter
 from ..demo.unit_converter import convert_this
 from ..io.parsers.blocks import make_table
-from ..proxy import UnitConversionNotDefinedError
+from ..proxy import UnitConversionNotDefinedError, MissingUnitConverterError
 
 
 def test_demo_converter__converts_values():
@@ -165,6 +166,30 @@ def test_convert_units__callable(table_cells, cuc):
 
     t = make_table(table_cells)
     t.convert_units(to=to_units_fun, converter=cuc)
+
+    # Conversion done on columns as requested
+    np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))
+    assert t["diameter"].unit == "m"
+    np.testing.assert_array_equal(t["mean_temp"].values, np.array([293.15, np.nan]))
+    assert t["mean_temp"].unit == "K"
+
+    # Column for which no conversion was requested stays unchanged
+    np.testing.assert_array_equal(t["depth"].values, np.array([666, 666]))
+    assert t["depth"].unit == "mm"
+
+
+def test_convert_units__using_default_converter(table_cells, cuc):
+    t = make_table(table_cells)
+
+    assert pdtable.units.default_converter is None
+    with raises(MissingUnitConverterError):
+        # No default unit converter was set
+        t.convert_units(to={"diameter": "m", "mean_temp": "K"})
+
+    # Now set a default converter
+    pdtable.units.default_converter = cuc
+    # Do conversion; no explicitly specified unit converter; uses default
+    t.convert_units(to={"diameter": "m", "mean_temp": "K"})
 
     # Conversion done on columns as requested
     np.testing.assert_array_equal(t["diameter"].values, np.array([42, 1]))

--- a/pdtable/units/__init__.py
+++ b/pdtable/units/__init__.py
@@ -1,0 +1,1 @@
+default_converter = None

--- a/pdtable/units/converter.py
+++ b/pdtable/units/converter.py
@@ -1,10 +1,10 @@
 """Default unit converter"""
 
 try:
-    from .pint import PintUnitConverter as DefaultUnitConverter
+    from .pint import PintUnitConverter
 
     # Singleton, for convenience.
-    pint_converter = DefaultUnitConverter()
+    pint_converter = PintUnitConverter()
 
 except ImportError as err:
     raise ImportError(


### PR DESCRIPTION
A bit of syntactic sugar for the user. 

Currently we need to explicitly specify a unit converter every time we convert units on a table. 
```
# Rather verbose:
t1.convert_units(to={"diameter": "m", "mean_temp": "K"}, converter=some_converter)
t2.convert_units(to={"foo": "Pa", "baz": "kg"}, converter=some_converter)  # <<<<<<< again...
...
```
The above is still possible, but with this PR we also have the following shorthand:
```
# Set a default converter once and for all
pdtable.units.default_converter = some_converter  # could be pdtable.pint_converter, or a custom one

# Do conversion; no explicitly specified unit converter; uses the default one
t1.convert_units(to={"diameter": "m", "mean_temp": "K"})
t2.convert_units(to={"foo": "Pa", "baz": "kg"})
...
```