### PR TITLE
Make pint_converter singleton work

### DIFF
--- a/pdtable/__init__.py
+++ b/pdtable/__init__.py
@@ -12,4 +12,4 @@ from .store import TableBundle, BlockType, BlockIterator
 from .io import ParseFixer
 from .io import read_csv, write_csv
 from .io import read_excel, write_excel
-from .units.pint import PintUnitConverter
+from .units.pint import PintUnitConverter, pint_converter

--- a/pdtable/test/test_units.py
+++ b/pdtable/test/test_units.py
@@ -8,7 +8,7 @@ from pint import DimensionalityError, UndefinedUnitError
 from pytest import fixture, raises
 
 import pdtable
-from pdtable.units import PintUnitConverter
+from pdtable.units.pint import PintUnitConverter, pint_converter
 from ..demo.unit_converter import convert_this
 from ..io.parsers.blocks import make_table
 from ..proxy import UnitConversionNotDefinedError, MissingUnitConverterError
@@ -42,7 +42,6 @@ def test_demo_converter__works():
 
 
 def test_pint_converter__works():
-    pint_converter = PintUnitConverter()
     # Converts single value
     assert pint_converter(1, "m", "mm") == (1000, "millimeter")
     assert pint_converter(0, "degC", "K") == (273.15, "kelvin")

--- a/pdtable/units/pint.py
+++ b/pdtable/units/pint.py
@@ -1,4 +1,9 @@
-"""A courtesy pint-based unit converter."""
+"""A courtesy pint-based unit converter.
+
+Here we define
+- a callable-class wrapper around Pint
+- a singleton instance of this class, for convenient use and reuse
+"""
 
 from typing import Union, Tuple
 
@@ -13,16 +18,7 @@ class PintUnitConverter:
     """
 
     def __init__(self):
-
-        try:
-            import pint
-        except ImportError as err:
-            raise ImportError(
-                "Unable to import 'pint'. "
-                "Please install 'pint' to use this pint-based unit converter."
-            ) from err
-        # Initialize unit registry once, keep it around for multiple calls
-        self.ureg = pint.UnitRegistry()
+        self.ureg = None  # Placeholder for pint unit registry
 
     def __call__(
         self,
@@ -49,6 +45,18 @@ class PintUnitConverter:
             representation of from_unit's base unit.
 
         """
+        try:
+            import pint
+        except ImportError as err:
+            raise ImportError(
+                "Unable to import 'pint'. "
+                "Please install 'pint' to use this pint-based unit converter."
+            ) from err
+
+        # Initialize unit registry once, keep it around for multiple calls
+        if self.ureg is None:
+            self.ureg = pint.UnitRegistry()
+
         if str(to_unit) == str(from_unit):
             # Null conversion
             return value, str(from_unit)
@@ -60,3 +68,7 @@ class PintUnitConverter:
             converted_quantity = self.ureg.Quantity(value, from_unit).to(to_unit)
 
         return converted_quantity.magnitude, str(converted_quantity.units)
+
+
+# Singleton
+pint_converter = PintUnitConverter()

--- a/test/test_optional_dependencies.py
+++ b/test/test_optional_dependencies.py
@@ -41,5 +41,4 @@ def test_pint_absent():
         import pdtable
         with raises(ImportError):
             # Fails on first use of pint_converter
-            p = pdtable.PintUnitConverter()
-            # assert p(1, "m", "mm") == (1000, "mm")
+            pdtable.pint_converter(1, "m", "mm")


### PR DESCRIPTION
Small tweak to make the pint_converter singleton work. I had previously dumped it because I couldn't figure out how to make it behave properly with pint being an optional dependency. Turns out it just needed this small tweak. 