### PR TITLE
Make FixParser give actually helpful error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The reader functions now output helpful error messages when parsing stops due to errors in the input table blocks.
+
 ### Changed
 
 - `write_excel()` parameter `path` renamed to `to`, reflecting the fact that it can write not only to file but also to binary stream; and by the same token, harmonizing its API with `read_csv()`. 

--- a/pdtable/io/parsers/blocks.py
+++ b/pdtable/io/parsers/blocks.py
@@ -70,8 +70,6 @@ def default_fixer(**kwargs):
         if type(fixer) is type:
             # It's a class, not an instance. Make an instance here.
             fixer = kwargs["fixer"]()
-        else:
-            assert isinstance(fixer, ParseFixer)
     else:
         fixer = ParseFixer()
     assert fixer is not None

--- a/pdtable/test/io/test_read_csv_fixer.py
+++ b/pdtable/test/io/test_read_csv_fixer.py
@@ -1,9 +1,11 @@
 import json
 import os
 from pathlib import Path
+from textwrap import dedent
 
 import pandas as pd
 import pytest
+from pytest import raises
 
 from pdtable import ParseFixer, BlockType
 from pdtable import read_csv
@@ -14,13 +16,26 @@ from pdtable.io.parsers.blocks import make_table
 
 class custom_test_fixer(ParseFixer):
     def __init__(self):
-        ParseFixer.__init__(self)
+        super().__init__()
         self.stop_on_errors = False
         self._called_from_test = True
 
 
 def input_dir() -> Path:
     return Path(__file__).parent / "input/with_errors"
+
+
+def test_displays_all_error_messages():
+    """By default, ParseFixer stops on errors and outputs a message
+    listing all encountered errors."""
+    expected_error_msg = dedent(
+        """\
+        Stopped parsing after 2 errors in table 'farm_cols1' with messages:
+        Duplicate column 'flt' at position 4 in table 'farm_cols1'.
+        Duplicate column 'flt' at position 5 in table 'farm_cols1'."""
+    )
+    with raises(ValueError, match=expected_error_msg):
+        blocks = list(read_csv(input_dir() / "cols1.csv"))
 
 
 def test_columns_duplicate():


### PR DESCRIPTION
Make FixParser give actually helpful error messages when it stops on errors, instead of a super generic, not very helpful one.

For example, was something like:
```
Stopped parsing after 2 errors in table 'farm_cols1'.
```
(... which meant you had to go figure out what exactly those errors were yourself...)

New error message is:
```
Stopped parsing after 2 errors in table 'farm_cols1' with messages:
        Duplicate column 'flt' at position 4 in table 'farm_cols1'.
        Duplicate column 'flt' at position 5 in table 'farm_cols1'.
```