### PR TITLE
Make Column iterable, solves #76

### DIFF
--- a/pdtable/proxy.py
+++ b/pdtable/proxy.py
@@ -34,11 +34,16 @@ class Column:
     """
 
     def __init__(self, df: TableDataFrame, name: str, table_info: ComplementaryTableInfo = None):
+        # TODO Instead of passing the entire df, consider only passing the relevant df
+        #  column Series and ColumnMetadata
         self._name = name
         self._values = df[name]
         if not table_info:
             table_info = get_table_info(df)
         self._meta = table_info.columns[name]
+
+    def __iter__(self):
+        yield from self._values
 
     @property
     def name(self):

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -70,6 +70,12 @@ def test_column(dft):
     # assert dft.cola[2] == 7
 
 
+def test_column__iter(dft):
+    """Can iterate over a Column's values"""
+    c = Column(dft, "cola")
+    assert [x for x in c] == [0, 1, 2, 3]
+
+
 def test_add_column(dft):
     frame.add_column(dft, "colc", [f"c{v}" for v in range(20, 24)], "text")
     assert dft.colc[0] == "c20"


### PR DESCRIPTION
Addresses #76 : for convenience, allow iterating over a proxy Column's values. 

@JanusWesenberg any reason not to do this?