### PR TITLE
Make TableBundle raise AttributeError on invalid attribute access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet.
+- Fix issue with invalid attribute access to `TableBundle` raising `KeyError` rather than `AttributeError`.
+- Enable `in`-operator for TableBundle.
 
 ## [0.0.6] - 2021-01-06
 

--- a/pdtable/store.py
+++ b/pdtable/store.py
@@ -102,7 +102,10 @@ class TableBundle:
                 self._tables_in_order.append(table)
 
     def __getattr__(self, name: str) -> TableType:
-        return self.unique(name)
+        try:
+            return self.unique(name)
+        except KeyError as e:
+            raise AttributeError(name) from e
 
     def __getitem__(self, idx: Union[str, int]) -> TableType:
         """Get table by numerical index or by name.
@@ -115,6 +118,9 @@ class TableBundle:
             return self._tables_in_order[idx]
 
         raise TypeError(f"getitem of type: {type(idx)}")
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._tables_named
 
     def __iter__(self) -> Iterator[str]:
         """Iterator over tables"""

--- a/pdtable/test/test_store.py
+++ b/pdtable/test/test_store.py
@@ -249,3 +249,4 @@ def test_TableBundle_attribute_error():
 def test_TableBundle_in_operator():
     bundle = TableBundle(parse_blocks(cell_rows))
     assert "foo" in bundle
+    assert "qux" not in bundle

--- a/pdtable/test/test_store.py
+++ b/pdtable/test/test_store.py
@@ -238,3 +238,14 @@ def test_TableBundle_all():
     assert len(lst) == 2
     for tab in lst:
         assert tab.name == "infs"
+
+
+def test_TableBundle_attribute_error():
+    bundle = TableBundle([])
+    with pytest.raises(AttributeError):
+        bundle.invalid_attribute_name
+
+
+def test_TableBundle_in_operator():
+    bundle = TableBundle(parse_blocks(cell_rows))
+    assert "foo" in bundle


### PR DESCRIPTION
Current implementation just forwards a KeyError, which leads to issues when sphinx-autodoc tries to mock TableBundle.

In addition I snuck in a totally unrelated ergonomics update to allow membership test with `in`.