### PR TITLE
Feature/write excel multiple sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. 
+### Added
+- [#92](https://github.com/startable/pdtable/issues/92) `write_excel()` can write to multiple sheets in a workbook. 
 
 ## [0.0.7] - 2021-01-18
 

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -1,6 +1,6 @@
 """Machinery to read/write Tables in an Excel workbook using openpyxl as engine."""
-from typing import Union, Iterable, Sequence, Any, Dict
 from os import PathLike
+from typing import Union, Iterable, Sequence, Any, Dict
 
 import openpyxl
 
@@ -27,10 +27,8 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(
-    tables: Union[Table, Iterable[Table], Dict[Table], Dict[Iterable[Table]]], path, na_rep
-):
-    """Writes tables to an Excel workbook at the specified path."""
+def write_excel_openpyxl(tables, path, na_rep):
+    """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
         # For convenience, pack it in a dict
@@ -42,7 +40,7 @@ def write_excel_openpyxl(
     for sheet_name in tables:
 
         tabs = tables[sheet_name]
-        if not isinstance(tabs, Iterable):
+        if isinstance(tabs, Table):
             # For convenience, pack single table in an iterable
             tabs = [tabs]
 

--- a/pdtable/io/csv.py
+++ b/pdtable/io/csv.py
@@ -100,7 +100,7 @@ def read_csv(
 
 
 def write_csv(
-    tables: Union[Table, Iterable[Table], TableBundle],
+    tables: Union[Table, Iterable[Table]],
     to: Union[str, os.PathLike, TextIO],
     sep: str = None,
     na_rep: str = "-",

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -56,7 +56,7 @@ def read_excel(
 
 
 def write_excel(
-    tables: Union[Table, Iterable[Table], Dict[Table], Dict[Iterable[Table]]],
+    tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
 ):

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -9,7 +9,7 @@ requiring them (read_excel() or write_excel()) are called for the first time.
 """
 import os
 from os import PathLike
-from typing import Union, Callable, Iterable, BinaryIO
+from typing import Union, Callable, Iterable, BinaryIO, Dict
 
 from .parsers.blocks import parse_blocks
 from .parsers.fixer import ParseFixer
@@ -56,7 +56,7 @@ def read_excel(
 
 
 def write_excel(
-    tables: Union[Table, Iterable[Table], TableBundle],
+    tables: Union[Table, Iterable[Table], Dict[Table], Dict[Iterable[Table]]],
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
 ):
@@ -70,7 +70,10 @@ def write_excel(
 
     Args:
         tables:
-            Table(s) to write. Can be a single Table or an iterable of Tables.
+            Table(s) to write.
+            * If a single Table or an iterable of Tables, writes to one sheet with default name.
+            * If a dict of {sheet_name: Table} or {sheet_name: Iterable[Table]}, writes tables to
+              sheets with specified names.
         to:
             File path or binary stream to which to write.
             If a file path, then this file gets created/overwritten and then closed after writing.

--- a/pdtable/store.py
+++ b/pdtable/store.py
@@ -122,7 +122,7 @@ class TableBundle:
     def __contains__(self, key: str) -> bool:
         return key in self._tables_named
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self) -> Iterator[Table]:
         """Iterator over tables"""
         return iter(self._tables_in_order)
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -70,7 +70,7 @@ def test_write_excel(tmp_path):
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
-    # Assert loaded worksheet looks as expected:
+    # First table is written as expected
     # - table header by row
     assert ws["A1"].value == "**foo"
     assert ws["A2"].value == "all"
@@ -88,6 +88,46 @@ def test_write_excel(tmp_path):
         assert abs(ws.cell(r, 3).value - d) <= datetime.timedelta(microseconds=1)
     assert ws.cell(8, 3).value == "-"
     assert [ws.cell(r, 4).value for r in range(5, 9)] == [1, 0, 1, 0]
+
+    # Second table is there as well (not going into details here)
+    assert ws["A10"].value == "**bar"
+
+    # Teardown
+    out_path.unlink()
+
+
+def test_write_excel__multiple_sheets(tmp_path):
+    """write_excel() can write tables to multiple sheets in a workbook"""
+
+    # Make a couple of tables
+    t = Table(name="foo")
+    t["place"] = ["home", "work", "beach", "wonderland"]
+    t.add_column("distance", list(range(3)) + [float("nan")], "km")
+    t.add_column(
+        "ETA",
+        pd.to_datetime(["2020-08-04 08:00", "2020-08-04 09:00", "2020-08-04 17:00", pd.NaT]),
+        "datetime",
+    )
+    t.add_column("is_hot", [True, False, True, False], "onoff")
+
+    t2 = Table(name="bar")
+    t2.add_column("digit", [1, 6, 42], "-")
+    t2.add_column("spelling", ["one", "six", "forty-two"], "text")
+
+    # Write tables to workbook, save, and re-load
+    out_path = tmp_path / "foo.xlsx"
+    write_excel({"sheet_one": [t, t2], "sheet_two": t2}, out_path)
+    wb = openpyxl.load_workbook(out_path)
+
+    # Workbook has the expected sheets
+    assert len(wb.worksheets) == 2
+    assert wb.sheetnames == ["sheet_one", "sheet_two"]
+    # First sheet contains the expected tables
+    assert wb.worksheets[0]["A1"].value == "**foo"
+    assert wb.worksheets[0]["A10"].value == "**bar"
+    # Second sheet contains the expected tables
+    assert wb.worksheets[1]["A1"].value == "**bar"
+    # Table details are tested elsewhere.
 
     # Teardown
     out_path.unlink()


### PR DESCRIPTION
Parameter `tables` of `write_excel()` can now also be given as a dict of {sheet_name: tables} specifying which tables should be written to what sheet (and the names of those sheets) in the output workbook.  

Example:
```
write_excel(
    tables={"first_sheet": [some_tables], "other_sheet": [more_tables], "final_sheet": one_last_table}, 
    to="foo.xlsx"
)
```
creates three sheets in the output workbook. 