### PR TITLE
Feature/85 write transposed tables, Closes #85, Closes #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#85](https://github.com/startable/pdtable/issues/85) CSV and Excel writers can write transposed tables.
 
+### Changed
+- [#42](https://github.com/startable/pdtable/issues/42) Table rendered as string or html should not show dummy index 
+
 ## [0.0.7] - 2021-01-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. 
+### Added
+- [#85](https://github.com/startable/pdtable/issues/85) CSV and Excel writers can write transposed tables.
 
 ## [0.0.7] - 2021-01-18
 

--- a/pdtable/frame.py
+++ b/pdtable/frame.py
@@ -199,7 +199,7 @@ def make_table_dataframe(
     **kwargs,
 ) -> TableDataFrame:
     """
-    Create TableDataFrame object from a pandas.DataFream and table metadata elements.
+    Create TableDataFrame object from a pandas.DataFrame and table metadata elements.
 
     Unknown keyword arguments (e.g. `name = ...`) are used to create a `TableMetadata` object.
     Alternatively, a `TableMetadata` object can be provided directly.

--- a/pdtable/io/_represent.py
+++ b/pdtable/io/_represent.py
@@ -1,3 +1,5 @@
+from itertools import repeat
+
 import pandas as pd
 
 from typing import Iterable
@@ -41,3 +43,9 @@ def _represent_row_elements(row: Iterable, units: Iterable, na_rep: str = "-"):
         else:
             # Leave everything else be as it is
             yield val
+
+
+def _represent_col_elements(values: Iterable, unit: str, na_rep: str = "-"):
+    """Prepare column value representations for writing"""
+    # Let's be lazy and just reuse the row code, sending it the same unit forever
+    yield from _represent_row_elements(values, repeat(unit), na_rep)

--- a/pdtable/proxy.py
+++ b/pdtable/proxy.py
@@ -259,8 +259,7 @@ class Table:
         m = self.metadata
         # TODO __repr__ shouldn't display the dataframe's index. Could also display units on their own line.  # noqa
         return (
-            f"**{m.name}\n{', '.join(s for s in m.destinations)}"
-            f"\n{self.as_dataframe_with_annotated_column_names()}"
+            f"**{m.name}\n{' '.join(s for s in m.destinations)}\n" + self.as_dataframe_with_annotated_column_names().to_string(index=False)
         )
 
     def __str__(self):

--- a/pdtable/table_metadata.py
+++ b/pdtable/table_metadata.py
@@ -51,6 +51,7 @@ class TableMetadata:
     origin: Optional[
         str
     ] = ""  # Should be replaced with a TableOrigin object to allow file-edit access
+    transposed: bool = False
 
     def __str__(self):
         dst = (

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -60,9 +60,11 @@ def test_write_excel(tmp_path):
     )
     t.add_column("is_hot", [True, False, True, False], "onoff")
 
+    # This one is transposed
     t2 = Table(name="bar")
     t2.add_column("digit", [1, 6, 42], "-")
     t2.add_column("spelling", ["one", "six", "forty-two"], "text")
+    t2.metadata.transposed = True
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -89,5 +89,14 @@ def test_write_excel(tmp_path):
     assert ws.cell(8, 3).value == "-"
     assert [ws.cell(r, 4).value for r in range(5, 9)] == [1, 0, 1, 0]
 
+    assert ws["A10"].value == "**bar*"
+    assert ws["A11"].value == "all"
+    # column headers (transposed)
+    assert [ws.cell(r, 1).value for r in range(12, 14)] == ["digit", "spelling"]
+    assert [ws.cell(r, 2).value for r in range(12, 14)] == ["-", "text"]
+    # column values (transposed)
+    assert [ws.cell(12, c).value for c in range(3, 6)] == [1, 6, 42]
+    assert [ws.cell(13, c).value for c in range(3, 6)] == ["one", "six", "forty-two"]
+
     # Teardown
     out_path.unlink()

--- a/pdtable/test/io/test_csv_writer.py
+++ b/pdtable/test/io/test_csv_writer.py
@@ -40,6 +40,36 @@ def test__table_to_csv():
         )
 
 
+def test__table_to_csv__writes_transposed_table():
+    # Make a TRANSPOSED table with content of various units
+    t = Table(name="foo")
+    t["place"] = ["home", "work", "beach", "wonderland"]
+    t.add_column("distance", list(range(3)) + [float("nan")], "km")
+    t.add_column(
+        "ETA",
+        pd.to_datetime(["2020-08-04 08:00", "2020-08-04 09:00", "2020-08-04 17:00", pd.NaT]),
+        "datetime",
+    )
+    t.add_column("is_hot", [True, False, True, False], "onoff")
+    t.metadata.transposed = True  # <<<< aha
+
+    # Write transposed table to stream
+    with io.StringIO() as out:
+        _table_to_csv(t, out, ";", "-")
+        # Stream content is as expected
+        assert out.getvalue() == dedent(
+            """\
+            **foo*;
+            all
+            place;text;home;work;beach;wonderland
+            distance;km;0.0;1.0;2.0;-
+            ETA;datetime;2020-08-04 08:00:00;2020-08-04 09:00:00;2020-08-04 17:00:00;-
+            is_hot;onoff;1;0;1;0
+
+            """
+        )
+
+
 def test_write_csv__writes_two_tables():
     # Make a couple of tables
     t = Table(name="foo")
@@ -52,9 +82,11 @@ def test_write_csv__writes_two_tables():
     )
     t.add_column("is_hot", [True, False, True, False], "onoff")
 
+    # This table is transposed
     t2 = Table(name="bar")
     t2.add_column("number", [1, 6, 42], "-")
     t2.add_column("spelling", ["one", "six", "forty-two"], "text")
+    t2.metadata.transposed = True
 
     # Write tables to stream
     with io.StringIO() as out:
@@ -71,13 +103,10 @@ def test_write_csv__writes_two_tables():
             beach;2.0;2020-08-04 17:00:00;1
             wonderland;-;-;0
 
-            **bar;
+            **bar*;
             all
-            number;spelling
-            -;text
-            1;one
-            6;six
-            42;forty-two
+            number;-;1;6;42
+            spelling;text;one;six;forty-two
 
             """
         )

--- a/pdtable/test/io/test_read_csv.py
+++ b/pdtable/test/io/test_read_csv.py
@@ -53,14 +53,19 @@ def test_read_csv(csv_data):
     met = [b for t, b in bl if t == BlockType.METADATA]
 
     assert len(met) == 1
-
     assert len(tables) == 3
+
+    # Correctly reads non-transposed table
     assert tables[0].df["place"][1] == "work"
+    assert not tables[0].metadata.transposed
+
+    # Correctly reads transposed table
     t2: Table = tables[2]
     assert t2.column_names == ["diameter", "melting_point"]
     assert len(t2.df) == 1
     assert t2.df["melting_point"][0] == 273
     assert len(template_rows) == 1
+    assert t2.metadata.transposed
 
 
 def test_read_csv__sep_is_comma(csv_data):

--- a/pdtable/test/io/test_read_excel.py
+++ b/pdtable/test/io/test_read_excel.py
@@ -27,15 +27,17 @@ def test_read_excel():
     t2.add_column("melting_point", [273], "K")
 
     expected_tables = [t0, t1, t2]
+    expected_transposed_flag = [False, False, True]
 
     # Read tables from file
     blocks = read_excel(Path(__file__).parent / "input" / "foo.xlsx")
     tables_read = [block for (block_type, block) in blocks if block_type == BlockType.TABLE]
     assert len(expected_tables) == len(tables_read)
 
-    # Assert read tables are equal to the expected ones
-    for te, tr in zip(expected_tables, tables_read):
+    # Tables read are equal to the expected ones
+    for te, tr, flag in zip(expected_tables, tables_read, expected_transposed_flag):
         assert te.equals(tr)
+        assert tr.metadata.transposed == flag
 
     # test_read_excel__from_stream
     with open(Path(__file__).parent / "input" / "foo.xlsx", "rb") as fh:

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -100,16 +100,21 @@ def test_table(dft):
 
 def test_table__str(dft):
     """String representation of a Table"""
-    t = Table(dft)
-    print(t)
-    assert str(t) == dedent("""\
+    string_rep = str(Table(dft))
+    lines = string_rep.split("\n")
+    expected_lines = dedent("""\
         **foo
         baz bar
          cola [-] colb [text]
                 0          v0
                 1          v1
                 2          v2
-                3          v3""")
+                3          v3""").split("\n")
+
+    assert lines[0] == expected_lines[0]
+    # destinations are stored as a set; order not necessarily preserved
+    assert lines[1] in ["bar baz", "baz bar"]
+    assert lines[2:] == expected_lines[2:]
 
 
 def test_df_operations(data_ab, data_cd):

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import pandas as pd
 import numpy as np
 
@@ -94,6 +96,20 @@ def test_table(dft):
     t["colc"] = range(20, 24)
     assert "colc" in t.column_names
     assert t["colc"].unit == "-"
+
+
+def test_table__str(dft):
+    """String representation of a Table"""
+    t = Table(dft)
+    print(t)
+    assert str(t) == dedent("""\
+        **foo
+        baz bar
+         cola [-] colb [text]
+                0          v0
+                1          v1
+                2          v2
+                3          v3""")
 
 
 def test_df_operations(data_ab, data_cd):


### PR DESCRIPTION
#85
`TableMetadata` now carries a `transposed` flag, set to `True` at read time if the table is [laid out in the transposed style](https://github.com/startable/pdtable/issues/69) as indicated by the `*` after its table name e.g. `**foo*`. Example: 
When read by `read_csv()`, 
```
**bar*;
all
number;-;1;6;42
spelling;text;one;six;forty-two
```
results in a `Table` with a metadata `transposed` flag set to `True`. (Whereas a non-transposed table leaves it `False`.)

When a table's transposed flag is `True`, `write_csv()` and `write_excel()` in turn write that table in the transposed style i.e. laid out with "horizontal columns" as in the example above (whereas before, all tables were written in the default style with vertical columns). 

The flag can be mutated manually if that's a thing you want to do: `foo_table.metadata.transposed = True  # or False`

#42 
While the hood was open, I made this small tweak to the string representation of `Table`: the dummy DataFrame index is no longer displayed. It was mostly clutter. 
Used to be
```
**foo
baz bar
   cola [-] colb [text]
0         0          v0
1         1          v1
2         2          v2
3         3          v3
```
Note the dummy index on the left. Now it's just
```
**foo
baz bar
 cola [-] colb [text]
        0          v0
        1          v1
        2          v2
        3          v3
```
