### PR TITLE
Feature/formatting excel wb

### DIFF
--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -82,12 +82,9 @@ def _append_table_to_openpyxl_worksheet(
 def _format_tables_in_worksheet(ws: OpenpyxlWorksheet) -> None:
     # Define styles to be used
     # TODO: These should perhaps live somewhere else?
-    font_name = 'Arial'
-    font_size = 10
-    header_font = Font(bold=True, color='1F4E78', name=font_name, size=font_size)
-    destination_font = Font(bold=True, color='808080', name=font_name, size=font_size)
-    name_font = Font(bold=True, name=font_name, size=font_size)
-    values_font = Font(name=font_name, size=font_size)
+    header_font = Font(bold=True, color='1F4E78')
+    destination_font = Font(bold=True, color='808080')
+    name_font = Font(bold=True)
     header_fill = PatternFill(start_color='D9D9D9', fill_type='solid')
     variable_fill = PatternFill(start_color='F2F2F2', fill_type='solid')
 
@@ -104,7 +101,6 @@ def _format_tables_in_worksheet(ws: OpenpyxlWorksheet) -> None:
             table_cols = [col for col in ws.iter_cols(min_row=i_start[i] + 3, max_row=i_end[i])]
             name_cells = table_cols[0]
             unit_cells = table_cols[1]
-            list_of_value_cells = table_cols[2:]
         else:
             header_row = rows[i_start[i]]
             destination_row = rows[i_start[i] + 1]
@@ -116,15 +112,12 @@ def _format_tables_in_worksheet(ws: OpenpyxlWorksheet) -> None:
                 table_rows = [row[:row_end] for row in table_rows]
             name_cells = table_rows[0]
             unit_cells = table_rows[1]
-            list_of_value_cells = table_rows[2:]
 
         # Format cells with defined styles
         _format_cells(header_row, font=header_font, fill=header_fill)
         _format_cells(destination_row, font=destination_font, fill=header_fill)
         _format_cells(name_cells, font=name_font, fill=variable_fill)
-        _format_cells(unit_cells, font=values_font, fill=variable_fill)
-        for value_cells in list_of_value_cells:
-            _format_cells(value_cells, font=values_font)
+        _format_cells(unit_cells, fill=variable_fill)
 
     # Widen columns
     num_cols = len(rows[0])
@@ -132,9 +125,9 @@ def _format_tables_in_worksheet(ws: OpenpyxlWorksheet) -> None:
         ws.column_dimensions[i_column].width = 20
 
 
-def _format_cells(cells, *, font: Font, fill: PatternFill = None) -> None:
+def _format_cells(cells, *, font: Font = None, fill: PatternFill = None) -> None:
     for cell in cells:
-        cell.font = font
-        if fill is None:
-            continue
-        cell.fill = fill
+        if font is not None:
+            cell.font = font
+        if fill is not None:
+            cell.fill = fill

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -9,7 +9,8 @@ try:
 except ImportError:
     # openpyxl < 2.6
     from openpyxl.worksheet import Worksheet as OpenpyxlWorksheet
-
+from openpyxl.styles import Font, PatternFill
+from openpyxl.utils import get_column_letter
 
 from pdtable import Table
 from pdtable.io._represent import _represent_row_elements, _represent_col_elements
@@ -73,3 +74,64 @@ def _append_table_to_openpyxl_worksheet(
             ws.append(_represent_row_elements(row, units, na_rep))
 
     ws.append([])  # blank row marking table end
+
+
+def _format_tables_in_worksheet(ws: OpenpyxlWorksheet) -> None:
+    # Define styles to be used
+    # TODO: These should perhaps live somewhere else?
+    font_name = 'Arial'
+    font_size = 10
+    header_font = Font(bold=True, color='1F4E78', name=font_name, size=font_size)
+    destination_font = Font(bold=True, color='808080', name=font_name, size=font_size)
+    name_font = Font(bold=True, name=font_name, size=font_size)
+    values_font = Font(name=font_name, size=font_size)
+    header_fill = PatternFill(start_color='D9D9D9', fill_type='solid')
+    variable_fill = PatternFill(start_color='F2F2F2', fill_type='solid')
+
+    # Identify placement of tables in sheet
+    rows = [row for row in ws.iter_rows()]
+    i_start = [i for i, row in enumerate(ws.iter_rows()) if row[0].value is not None and row[0].value.startswith('**')]
+    i_end = [i - 1 for i in i_start if i > 0] + [len(rows)]
+
+    # Loop through tables
+    for i in range(len(i_start)):
+        if rows[i_start[i]][0].value[-1] == '*':   # Transposed table
+            header_row = rows[i_start[i]]
+            destination_row = rows[i_start[i] + 1]
+            table_cols = [col for col in ws.iter_cols(min_row=i_start[i] + 3, max_row=i_end[i])]
+            name_cells = table_cols[0]
+            unit_cells = table_cols[1]
+            list_of_value_cells = table_cols[2:]
+        else:
+            header_row = rows[i_start[i]]
+            destination_row = rows[i_start[i] + 1]
+            table_rows = rows[i_start[i] + 2:i_end[i]]
+            row_end = len([cell for cell in table_rows[0] if cell.value is not None])
+            if row_end < len(table_rows[0]):    # Cut off rows outside table
+                header_row = header_row[:row_end]
+                destination_row = destination_row[:row_end]
+                table_rows = [row[:row_end] for row in table_rows]
+            name_cells = table_rows[0]
+            unit_cells = table_rows[1]
+            list_of_value_cells = table_rows[2:]
+
+        # Format cells with defined styles
+        _format_cells(header_row, font=header_font, fill=header_fill)
+        _format_cells(destination_row, font=destination_font, fill=header_fill)
+        _format_cells(name_cells, font=name_font, fill=variable_fill)
+        _format_cells(unit_cells, font=values_font, fill=variable_fill)
+        for value_cells in list_of_value_cells:
+            _format_cells(value_cells, font=values_font)
+
+    # Widen columns
+    num_cols = len(rows[0])
+    for i_column in [get_column_letter(i + 1) for i in range(num_cols + 1)]:
+        ws.column_dimensions[i_column].width = 20
+
+
+def _format_cells(cells, *, font: Font, fill: PatternFill = None) -> None:
+    for cell in cells:
+        cell.font = font
+        if fill is None:
+            continue
+        cell.fill = fill

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -28,7 +28,7 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(tables, path, na_rep, format_wb):
+def write_excel_openpyxl(tables, path, na_rep, prettify):
     """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
@@ -49,7 +49,7 @@ def write_excel_openpyxl(tables, path, na_rep, format_wb):
         for t in tabs:
             _append_table_to_openpyxl_worksheet(t, ws, na_rep)
 
-        if format_wb:
+        if prettify:
             _format_tables_in_worksheet(ws)
 
     wb.save(path)

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -28,7 +28,7 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(tables, path, na_rep):
+def write_excel_openpyxl(tables, path, na_rep, format_wb):
     """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
@@ -48,6 +48,9 @@ def write_excel_openpyxl(tables, path, na_rep):
         ws = wb.create_sheet(title=sheet_name)
         for t in tabs:
             _append_table_to_openpyxl_worksheet(t, ws, na_rep)
+
+        if format_wb:
+            _format_tables_in_worksheet(ws)
 
     wb.save(path)
 

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -28,7 +28,7 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(tables, path, na_rep, prettify, num_blank_rows_between_tables):
+def write_excel_openpyxl(tables, path, na_rep, style, num_blank_rows_between_tables):
     """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
@@ -52,7 +52,7 @@ def write_excel_openpyxl(tables, path, na_rep, prettify, num_blank_rows_between_
             table_dimensions.append((len(t.df), len(t.df.columns), t.metadata.transposed))
             _append_table_to_openpyxl_worksheet(t, ws, num_blank_rows_between_tables, na_rep)
 
-        if prettify:
+        if style:
             _format_tables_in_worksheet(ws, table_dimensions, num_blank_rows_between_tables)
 
     wb.save(path)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -60,7 +60,7 @@ def write_excel(
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
     num_blank_rows_between_tables: int = 1,
-    prettify: bool = False
+    style: bool = False
 ):
     """Writes one or more tables to an Excel workbook.
 
@@ -88,8 +88,8 @@ def write_excel(
         num_blank_rows_between_tables:
             Optional; Number of blank rows between tables.
             Default is 1.
-        prettify:
-            Optional; Whether or not to apply standard StarTable formatting to Excel workbook file.
+        style:
+            Optional; Whether or not to apply standard StarTable style to Excel workbook file.
             Default is False.
     """
     try:
@@ -102,4 +102,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep, prettify, num_blank_rows_between_tables)
+    write_excel_func(tables, to, na_rep, style, num_blank_rows_between_tables)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -59,7 +59,7 @@ def write_excel(
     tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
-    format_wb: bool = False
+    prettify: bool = False
 ):
     """Writes one or more tables to an Excel workbook.
 
@@ -84,7 +84,7 @@ def write_excel(
             Optional; String representation of missing values (NaN, None, NaT).
             If overriding the default '-', it is recommended to use another value compliant with
             the StarTable standard.
-        format_wb:
+        prettify:
             Optional; Whether or not to apply standard StarTable formatting to Excel workbook file.
             Default is False.
     """
@@ -98,4 +98,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep, format_wb)
+    write_excel_func(tables, to, na_rep, prettify)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -59,6 +59,7 @@ def write_excel(
     tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
+    num_blank_rows_between_tables: int = 1,
     prettify: bool = False
 ):
     """Writes one or more tables to an Excel workbook.
@@ -84,6 +85,9 @@ def write_excel(
             Optional; String representation of missing values (NaN, None, NaT).
             If overriding the default '-', it is recommended to use another value compliant with
             the StarTable standard.
+        num_blank_rows_between_tables:
+            Optional; Number of blank rows between tables.
+            Default is 1.
         prettify:
             Optional; Whether or not to apply standard StarTable formatting to Excel workbook file.
             Default is False.
@@ -98,4 +102,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep, prettify)
+    write_excel_func(tables, to, na_rep, prettify, num_blank_rows_between_tables)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -59,6 +59,7 @@ def write_excel(
     tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
     to: Union[str, os.PathLike, BinaryIO],
     na_rep: str = "-",
+    format_wb: bool = False
 ):
     """Writes one or more tables to an Excel workbook.
 
@@ -83,6 +84,9 @@ def write_excel(
             Optional; String representation of missing values (NaN, None, NaT).
             If overriding the default '-', it is recommended to use another value compliant with
             the StarTable standard.
+        format_wb:
+            Optional; Whether or not to apply standard StarTable formatting to Excel workbook file.
+            Default is False.
     """
     try:
         from ._excel_openpyxl import write_excel_openpyxl as write_excel_func
@@ -94,4 +98,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep)
+    write_excel_func(tables, to, na_rep, format_wb)

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -162,7 +162,7 @@ def test_write_excel_with_formatting(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2], out_path, format_wb=True)
+    write_excel([t, t2], out_path, prettify=True)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -168,7 +168,7 @@ def test_write_excel_with_formatting(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2, t3], out_path, prettify=True)
+    write_excel([t, t2, t3], out_path, style=True)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
@@ -295,7 +295,7 @@ def test_write_excel_with_formatting_and_2_blank_rows_between_tables(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2, t3], out_path, prettify=True, num_blank_rows_between_tables=2)
+    write_excel([t, t2, t3], out_path, style=True, num_blank_rows_between_tables=2)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -140,3 +140,139 @@ def test_write_excel__multiple_sheets(tmp_path):
 
     # Teardown
     out_path.unlink()
+
+
+def test_write_excel_with_formatting(tmp_path):
+    # Make a couple of tables
+    t = Table(name="foo")
+    t["place"] = ["home", "work", "beach", "wonderland"]
+    t.add_column("distance", list(range(3)) + [float("nan")], "km")
+    t.add_column(
+        "ETA",
+        pd.to_datetime(["2020-08-04 08:00", "2020-08-04 09:00", "2020-08-04 17:00", pd.NaT]),
+        "datetime",
+    )
+    t.add_column("is_hot", [True, False, True, False], "onoff")
+
+    # This one is transposed
+    t2 = Table(name="bar")
+    t2.add_column("digit", [1, 6, 42], "-")
+    t2.add_column("spelling", ["one", "six", "forty-two"], "text")
+    t2.metadata.transposed = True
+
+    # Write tables to workbook, save, and re-load
+    out_path = tmp_path / "foo.xlsx"
+    write_excel([t, t2], out_path, format_wb=True)
+    wb = openpyxl.load_workbook(out_path)
+    ws = wb.active
+
+    # First table is written as expected
+    # - table header by row
+    assert ws["A1"].value == "**foo"
+    assert ws["A2"].value == "all"
+    assert [ws.cell(3, c).value for c in range(1, 5)] == ["place", "distance", "ETA", "is_hot"]
+    assert [ws.cell(4, c).value for c in range(1, 5)] == ["text", "km", "datetime", "onoff"]
+
+    # Check table formatting
+    assert ws["A1"].fill.fill_type == "solid"
+    assert ws["A1"].fill.start_color.value == "00D9D9D9"
+    assert ws["A1"].font.color.value == "001F4E78"
+    assert ws["A1"].font.size == 10
+    assert ws["A1"].font.name == "Arial"
+    assert ws["A1"].font.bold is True
+
+    assert ws["A2"].fill.fill_type == "solid"
+    assert ws["A2"].fill.start_color.value == "00D9D9D9"
+    assert ws["A2"].font.color.value == "00808080"
+    assert ws["A2"].font.size == 10
+    assert ws["A2"].font.name == "Arial"
+    assert ws["A2"].font.bold is True
+
+    assert [ws.cell(3, c).fill.fill_type for c in range(1, 5)] == ["solid"] * 4
+    assert [ws.cell(3, c).fill.start_color.value for c in range(1, 5)] == ["00F2F2F2"] * 4
+    assert [ws.cell(3, c).font.size for c in range(1, 5)] == [10] * 4
+    assert [ws.cell(3, c).font.name for c in range(1, 5)] == ["Arial"] * 4
+    assert [ws.cell(3, c).font.bold for c in range(1, 5)] == [True] * 4
+
+    assert [ws.cell(4, c).fill.fill_type for c in range(1, 5)] == ["solid"] * 4
+    assert [ws.cell(4, c).fill.start_color.value for c in range(1, 5)] == ["00F2F2F2"] * 4
+    assert [ws.cell(4, c).font.size for c in range(1, 5)] == [10] * 4
+    assert [ws.cell(4, c).font.name for c in range(1, 5)] == ["Arial"] * 4
+    assert [ws.cell(4, c).font.bold for c in range(1, 5)] == [False] * 4
+
+    # - table data by column
+    assert [ws.cell(r, 1).value for r in range(5, 9)] == ["home", "work", "beach", "wonderland"]
+    assert [ws.cell(r, 1).fill.fill_type for r in range(5, 9)] == [None] * 4
+    assert [ws.cell(r, 1).font.size for r in range(5, 9)] == [10] * 4
+    assert [ws.cell(r, 1).font.name for r in range(5, 9)] == ["Arial"] * 4
+    assert [ws.cell(r, 1).font.bold for r in range(5, 9)] == [False] * 4
+
+    assert [ws.cell(r, 2).value for r in range(5, 9)] == [0, 1, 2, "-"]
+    assert [ws.cell(r, 2).fill.fill_type for r in range(5, 9)] == [None] * 4
+    assert [ws.cell(r, 2).font.size for r in range(5, 9)] == [10] * 4
+    assert [ws.cell(r, 2).font.name for r in range(5, 9)] == ["Arial"] * 4
+    assert [ws.cell(r, 2).font.bold for r in range(5, 9)] == [False] * 4
+    for r, d in zip(
+        range(5, 8), pd.to_datetime(["2020-08-04 08:00", "2020-08-04 09:00", "2020-08-04 17:00"])
+    ):
+        # workaround openpyxl bug: https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1493
+        # openpyxl adds a spurious microsecond to some datetimes.
+        assert abs(ws.cell(r, 3).value - d) <= datetime.timedelta(microseconds=1)
+        assert ws.cell(r, 3).fill.fill_type is None
+        assert ws.cell(r, 3).font.size == 10
+        assert ws.cell(r, 3).font.name == "Arial"
+        assert ws.cell(r, 3).font.bold is False
+    assert ws.cell(8, 3).value == "-"
+    assert [ws.cell(r, 4).value for r in range(5, 9)] == [1, 0, 1, 0]
+    assert [ws.cell(r, 4).fill.fill_type for r in range(5, 9)] == [None] * 4
+    assert [ws.cell(r, 4).font.size for r in range(5, 9)] == [10] * 4
+    assert [ws.cell(r, 4).font.name for r in range(5, 9)] == ["Arial"] * 4
+    assert [ws.cell(r, 4).font.bold for r in range(5, 9)] == [False] * 4
+
+    # Second table is there as well
+    assert ws["A10"].value == "**bar*"
+    assert ws["A10"].fill.fill_type == "solid"
+    assert ws["A10"].fill.start_color.value == "00D9D9D9"
+    assert ws["A10"].font.color.value == "001F4E78"
+    assert ws["A10"].font.size == 10
+    assert ws["A10"].font.name == "Arial"
+    assert ws["A10"].font.bold is True
+
+    assert ws["A11"].value == "all"
+    assert ws["A11"].fill.fill_type == "solid"
+    assert ws["A11"].fill.start_color.value == "00D9D9D9"
+    assert ws["A11"].font.color.value == "00808080"
+    assert ws["A11"].font.size == 10
+    assert ws["A11"].font.name == "Arial"
+    assert ws["A11"].font.bold is True
+
+    # column headers (transposed)
+    assert [ws.cell(r, 1).value for r in range(12, 14)] == ["digit", "spelling"]
+    assert [ws.cell(r, 1).fill.fill_type for r in range(12, 14)] == ["solid"] * 2
+    assert [ws.cell(r, 1).fill.start_color.value for r in range(12, 14)] == ["00F2F2F2"] * 2
+    assert [ws.cell(r, 1).font.size for r in range(12, 14)] == [10] * 2
+    assert [ws.cell(r, 1).font.name for r in range(12, 14)] == ["Arial"] * 2
+    assert [ws.cell(r, 1).font.bold for r in range(12, 14)] == [True] * 2
+
+    assert [ws.cell(r, 2).value for r in range(12, 14)] == ["-", "text"]
+    assert [ws.cell(r, 2).fill.fill_type for r in range(12, 14)] == ["solid"] * 2
+    assert [ws.cell(r, 2).fill.start_color.value for r in range(12, 14)] == ["00F2F2F2"] * 2
+    assert [ws.cell(r, 2).font.size for r in range(12, 14)] == [10] * 2
+    assert [ws.cell(r, 2).font.name for r in range(12, 14)] == ["Arial"] * 2
+    assert [ws.cell(r, 2).font.bold for r in range(12, 14)] == [False] * 2
+
+    # column values (transposed)
+    assert [ws.cell(12, c).value for c in range(3, 6)] == [1, 6, 42]
+    assert [ws.cell(12, c).fill.fill_type for c in range(3, 6)] == [None] * 3
+    assert [ws.cell(12, c).font.size for c in range(3, 6)] == [10] * 3
+    assert [ws.cell(12, c).font.name for c in range(3, 6)] == ["Arial"] * 3
+    assert [ws.cell(12, c).font.bold for c in range(3, 6)] == [False] * 3
+
+    assert [ws.cell(13, c).value for c in range(3, 6)] == ["one", "six", "forty-two"]
+    assert [ws.cell(13, c).fill.fill_type for c in range(3, 6)] == [None] * 3
+    assert [ws.cell(13, c).font.size for c in range(3, 6)] == [10] * 3
+    assert [ws.cell(13, c).font.name for c in range(3, 6)] == ["Arial"] * 3
+    assert [ws.cell(13, c).font.bold for c in range(3, 6)] == [False] * 3
+
+    # Teardown
+    out_path.unlink()

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -160,9 +160,15 @@ def test_write_excel_with_formatting(tmp_path):
     t2.add_column("spelling", ["one", "six", "forty-two"], "text")
     t2.metadata.transposed = True
 
+    # This one is also transposed
+    t3 = Table(name="bas")
+    t3.add_column("digit", [1, 6, 42], "-")
+    t3.add_column("spelling", ["one", "six", "forty-two"], "text")
+    t3.metadata.transposed = True
+
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2], out_path, prettify=True)
+    write_excel([t, t2, t3], out_path, prettify=True)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
@@ -245,6 +251,19 @@ def test_write_excel_with_formatting(tmp_path):
     assert [ws.cell(13, c).value for c in range(3, 6)] == ["one", "six", "forty-two"]
     assert [ws.cell(13, c).fill.fill_type for c in range(3, 6)] == [None] * 3
     assert [ws.cell(13, c).font.bold for c in range(3, 6)] == [False] * 3
+
+    # Third table is there as well
+    assert ws["A15"].value == "**bas*"
+    assert ws["A15"].fill.fill_type == "solid"
+    assert ws["A15"].fill.start_color.value == "00D9D9D9"
+    assert ws["A15"].font.color.value == "001F4E78"
+    assert ws["A15"].font.bold is True
+
+    assert ws["A16"].value == "all"
+    assert ws["A16"].fill.fill_type == "solid"
+    assert ws["A16"].fill.start_color.value == "00D9D9D9"
+    assert ws["A16"].font.color.value == "00808080"
+    assert ws["A16"].font.bold is True
 
     # Teardown
     out_path.unlink()

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -177,40 +177,28 @@ def test_write_excel_with_formatting(tmp_path):
     assert ws["A1"].fill.fill_type == "solid"
     assert ws["A1"].fill.start_color.value == "00D9D9D9"
     assert ws["A1"].font.color.value == "001F4E78"
-    assert ws["A1"].font.size == 10
-    assert ws["A1"].font.name == "Arial"
     assert ws["A1"].font.bold is True
 
     assert ws["A2"].fill.fill_type == "solid"
     assert ws["A2"].fill.start_color.value == "00D9D9D9"
     assert ws["A2"].font.color.value == "00808080"
-    assert ws["A2"].font.size == 10
-    assert ws["A2"].font.name == "Arial"
     assert ws["A2"].font.bold is True
 
     assert [ws.cell(3, c).fill.fill_type for c in range(1, 5)] == ["solid"] * 4
     assert [ws.cell(3, c).fill.start_color.value for c in range(1, 5)] == ["00F2F2F2"] * 4
-    assert [ws.cell(3, c).font.size for c in range(1, 5)] == [10] * 4
-    assert [ws.cell(3, c).font.name for c in range(1, 5)] == ["Arial"] * 4
     assert [ws.cell(3, c).font.bold for c in range(1, 5)] == [True] * 4
 
     assert [ws.cell(4, c).fill.fill_type for c in range(1, 5)] == ["solid"] * 4
     assert [ws.cell(4, c).fill.start_color.value for c in range(1, 5)] == ["00F2F2F2"] * 4
-    assert [ws.cell(4, c).font.size for c in range(1, 5)] == [10] * 4
-    assert [ws.cell(4, c).font.name for c in range(1, 5)] == ["Arial"] * 4
     assert [ws.cell(4, c).font.bold for c in range(1, 5)] == [False] * 4
 
     # - table data by column
     assert [ws.cell(r, 1).value for r in range(5, 9)] == ["home", "work", "beach", "wonderland"]
     assert [ws.cell(r, 1).fill.fill_type for r in range(5, 9)] == [None] * 4
-    assert [ws.cell(r, 1).font.size for r in range(5, 9)] == [10] * 4
-    assert [ws.cell(r, 1).font.name for r in range(5, 9)] == ["Arial"] * 4
     assert [ws.cell(r, 1).font.bold for r in range(5, 9)] == [False] * 4
 
     assert [ws.cell(r, 2).value for r in range(5, 9)] == [0, 1, 2, "-"]
     assert [ws.cell(r, 2).fill.fill_type for r in range(5, 9)] == [None] * 4
-    assert [ws.cell(r, 2).font.size for r in range(5, 9)] == [10] * 4
-    assert [ws.cell(r, 2).font.name for r in range(5, 9)] == ["Arial"] * 4
     assert [ws.cell(r, 2).font.bold for r in range(5, 9)] == [False] * 4
     for r, d in zip(
         range(5, 8), pd.to_datetime(["2020-08-04 08:00", "2020-08-04 09:00", "2020-08-04 17:00"])
@@ -219,14 +207,10 @@ def test_write_excel_with_formatting(tmp_path):
         # openpyxl adds a spurious microsecond to some datetimes.
         assert abs(ws.cell(r, 3).value - d) <= datetime.timedelta(microseconds=1)
         assert ws.cell(r, 3).fill.fill_type is None
-        assert ws.cell(r, 3).font.size == 10
-        assert ws.cell(r, 3).font.name == "Arial"
         assert ws.cell(r, 3).font.bold is False
     assert ws.cell(8, 3).value == "-"
     assert [ws.cell(r, 4).value for r in range(5, 9)] == [1, 0, 1, 0]
     assert [ws.cell(r, 4).fill.fill_type for r in range(5, 9)] == [None] * 4
-    assert [ws.cell(r, 4).font.size for r in range(5, 9)] == [10] * 4
-    assert [ws.cell(r, 4).font.name for r in range(5, 9)] == ["Arial"] * 4
     assert [ws.cell(r, 4).font.bold for r in range(5, 9)] == [False] * 4
 
     # Second table is there as well
@@ -234,44 +218,32 @@ def test_write_excel_with_formatting(tmp_path):
     assert ws["A10"].fill.fill_type == "solid"
     assert ws["A10"].fill.start_color.value == "00D9D9D9"
     assert ws["A10"].font.color.value == "001F4E78"
-    assert ws["A10"].font.size == 10
-    assert ws["A10"].font.name == "Arial"
     assert ws["A10"].font.bold is True
 
     assert ws["A11"].value == "all"
     assert ws["A11"].fill.fill_type == "solid"
     assert ws["A11"].fill.start_color.value == "00D9D9D9"
     assert ws["A11"].font.color.value == "00808080"
-    assert ws["A11"].font.size == 10
-    assert ws["A11"].font.name == "Arial"
     assert ws["A11"].font.bold is True
 
     # column headers (transposed)
     assert [ws.cell(r, 1).value for r in range(12, 14)] == ["digit", "spelling"]
     assert [ws.cell(r, 1).fill.fill_type for r in range(12, 14)] == ["solid"] * 2
     assert [ws.cell(r, 1).fill.start_color.value for r in range(12, 14)] == ["00F2F2F2"] * 2
-    assert [ws.cell(r, 1).font.size for r in range(12, 14)] == [10] * 2
-    assert [ws.cell(r, 1).font.name for r in range(12, 14)] == ["Arial"] * 2
     assert [ws.cell(r, 1).font.bold for r in range(12, 14)] == [True] * 2
 
     assert [ws.cell(r, 2).value for r in range(12, 14)] == ["-", "text"]
     assert [ws.cell(r, 2).fill.fill_type for r in range(12, 14)] == ["solid"] * 2
     assert [ws.cell(r, 2).fill.start_color.value for r in range(12, 14)] == ["00F2F2F2"] * 2
-    assert [ws.cell(r, 2).font.size for r in range(12, 14)] == [10] * 2
-    assert [ws.cell(r, 2).font.name for r in range(12, 14)] == ["Arial"] * 2
     assert [ws.cell(r, 2).font.bold for r in range(12, 14)] == [False] * 2
 
     # column values (transposed)
     assert [ws.cell(12, c).value for c in range(3, 6)] == [1, 6, 42]
     assert [ws.cell(12, c).fill.fill_type for c in range(3, 6)] == [None] * 3
-    assert [ws.cell(12, c).font.size for c in range(3, 6)] == [10] * 3
-    assert [ws.cell(12, c).font.name for c in range(3, 6)] == ["Arial"] * 3
     assert [ws.cell(12, c).font.bold for c in range(3, 6)] == [False] * 3
 
     assert [ws.cell(13, c).value for c in range(3, 6)] == ["one", "six", "forty-two"]
     assert [ws.cell(13, c).fill.fill_type for c in range(3, 6)] == [None] * 3
-    assert [ws.cell(13, c).font.size for c in range(3, 6)] == [10] * 3
-    assert [ws.cell(13, c).font.name for c in range(3, 6)] == ["Arial"] * 3
     assert [ws.cell(13, c).font.bold for c in range(3, 6)] == [False] * 3
 
     # Teardown


### PR DESCRIPTION
This PR enables formatting when writing StarTables to Excel workbook.

The header, destination, variable names, unit and values are all formatted differently.
The font, font size, font colors and fill colors should ideally be defined somewhere else than deep within the formatting routine itself.

A lot of effort goes into disassembling the workbook into recognizable StarTable elements. There might be a danger to doing this decoupled from, say, the writer itself.
I considered if it could be done within `_append_table_to_openpyxl_worksheet` itself, but `ws.append` returns `None`, and I do not think `ws.append` can handle already formatted cells.