### PR TITLE
Replace deprecated np.bool with its designated successor, bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. 
-
+### Fixed
+- Replaced the one remaining reference to `numpy.bool` (now deprecated from numpy) with its designated successor, plain ol' built-in `bool`.
 ## [0.0.9] - 2021-02-23
 
 ### Added

--- a/pdtable/io/parsers/columns.py
+++ b/pdtable/io/parsers/columns.py
@@ -65,7 +65,7 @@ def _parse_onoff_column(values: Iterable, fixer: ParseFixer = None):
                 bool_values.append(fix_value)
             else:
                 raise ValueError("Illegal value in onoff column", val) from err
-    return np.array(bool_values, dtype=np.bool)
+    return np.array(bool_values, dtype=bool)
 
 
 def _float_convert(val: str) -> float:


### PR DESCRIPTION
Got rid of the one instance of `np.bool` in pdtable, replacing it with its designated successor, plain ol' built-in `bool`. Usage of `np.bool` was triggering the following deprecation warning. Now gone. 
```
[...]\pdtable\io\parsers\columns.py:68: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return np.array(bool_values, dtype=np.bool)
```