### PR TITLE
Feature/96 write excel custom style, closes #96, closes #97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No unreleased changes yet. 
 
+### Changed
+
+- `write_excel()` parameter `num_blank_rows_between_tables` renamed to `sep_lines`.
+
+
 ## [0.0.9] - 2021-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ No unreleased changes yet.
 
 ### Changed
 
-- Optionally specify custom styles in `write_excel()` by passing to parameter `style` a JSON-like 
-structure of dicts.
+- `write_excel()` parameter `style` renamed to `styles`.
+- Optionally specify custom styles in `write_excel()` by passing to parameter `styles` a JSON-like structure of dicts.
+- When `write_excel()` parameter `styles` is truthy, transposed tables' column units and values are horizontally centered by default. This default is overridden by any horizontal alignment specified explicitly in `styles`. 
 - `write_excel()` parameter `num_blank_rows_between_tables` renamed to `sep_lines` for conciseness.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ No unreleased changes yet.
 
 ### Changed
 
-- `write_excel()` parameter `num_blank_rows_between_tables` renamed to `sep_lines`.
+- Optionally specify custom styles in `write_excel()` by passing to parameter `style` a JSON-like 
+structure of dicts.
+- `write_excel()` parameter `num_blank_rows_between_tables` renamed to `sep_lines` for conciseness.
 
 
 ## [0.0.9] - 2021-02-23

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -11,7 +11,7 @@ except ImportError:
     # openpyxl < 2.6
     from openpyxl.worksheet import Worksheet as OpenpyxlWorksheet
 from openpyxl.cell.cell import Cell
-from openpyxl.styles import Font, PatternFill, Color
+from openpyxl.styles import Font, PatternFill, Color, Alignment
 from openpyxl.utils import get_column_letter
 
 from pdtable import Table
@@ -145,18 +145,25 @@ def _style_cells(cells: Iterable[Cell], style: Optional[Dict]) -> None:
         return
     # Font: blindly assume JSON schema matches Font.__init__() parameters (reasonable enough)
     font_args = style.get("font")
-    font = Font(**style.get("font", {})) if font_args else None
+    font = Font(**font_args) if font_args else None
     # Fill: the only relevant thing is the fill color
     fill_color = deep_get(style, ["fill", "color"])
     fill = PatternFill(start_color=fill_color, fill_type="solid") if fill_color else None
+    # Alignment: blindly assume JSON schema matches Alignment.__init__() params (reasonable enough)
+    alignment_args = style.get("alignment")
+    alignment = Alignment(**alignment_args) if alignment_args else None
+    # TODO throw clearer exception if non-existent arg passed to Font() or Alignment()
+    # TODO throw clearer exception on invalid arg value for all these things
     for cell in cells:
-        # Code inspection complains that attributes Cell.font and Cell.style are read-only, but
-        # mutating them is, in fact, the correct, documented way of applying styles to cells.
+        # Code inspection complains that Cell attributes are read-only, but mutating them is,
+        # in fact, the correct, documented way of applying styles to cells.
         # Ref: https://openpyxl.readthedocs.io/en/stable/styles.html#cell-styles
         if font is not None:
             cell.font = font  # noqa
         if fill is not None:
             cell.fill = fill  # noqa
+        if alignment is not None:
+            cell.alignment = alignment  # noqa
 
 
 def _style_tables_in_worksheet(

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -61,7 +61,7 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(tables, path, na_rep, style, sep_lines):
+def write_excel_openpyxl(tables, path, na_rep, styles, sep_lines):
     """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
@@ -85,9 +85,9 @@ def write_excel_openpyxl(tables, path, na_rep, style, sep_lines):
             table_dimensions.append((len(t.df), len(t.df.columns), t.metadata.transposed))
             _append_table_to_openpyxl_worksheet(t, ws, sep_lines, na_rep)
 
-        if style:
-            style = DEFAULT_STYLE_SPEC if style is True else style
-            _format_tables_in_worksheet(ws, table_dimensions, style, sep_lines)
+        if styles:
+            styles = DEFAULT_STYLE_SPEC if styles is True else styles
+            _format_tables_in_worksheet(ws, table_dimensions, styles, sep_lines)
 
     wb.save(path)
 

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -117,15 +117,35 @@ def _append_table_to_openpyxl_worksheet(
         ws.append([])  # blank row marking table end
 
 
+def deep_get(dictionary, keys, default=None):
+    """Get value from nested dictionaries.
+
+    Example:
+        d = {'meta': {'status': 'OK', 'status_code': 200}}
+        deep_get(d, ['meta', 'status_code'])          # => 200
+        deep_get(d, ['garbage', 'status_code'])       # => None
+        deep_get(d, ['meta', 'garbage'], default='-') # => '-'
+    """
+    if dictionary is None:
+        return default
+    if not keys:
+        return dictionary
+    return deep_get(dictionary.get(keys[0]), keys[1:], default)
+
+
+def _make_style_objects(style: Dict) -> Tuple[Font, PatternFill]:
+    pass
+
+
 def _format_tables_in_worksheet(
-        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], style: Dict, sep_lines: int
+        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], styles: Dict, sep_lines: int
 ) -> None:
     # Define styles to be used
-    table_name_font = Font(bold=style['table_name']['font']['bold'], color=style['table_name']['font']['color'])
-    destination_font = Font(bold=style['destinations']['font']['bold'], color=style['destinations']['font']['color'])
-    col_name_font = Font(bold=style['column_names']['font']['bold'], color=style['column_names']['font']['color'])
+    table_name_font = Font(bold=styles['table_name']['font']['bold'], color=styles['table_name']['font']['color'])
+    destination_font = Font(bold=styles['destinations']['font']['bold'], color=styles['destinations']['font']['color'])
+    col_name_font = Font(bold=styles['column_names']['font']['bold'], color=styles['column_names']['font']['color'])
     # TODO deal with non-specified style elements!
-    table_name_fill = PatternFill(start_color=style['table_name']['fill']['color'], fill_type='solid')
+    table_name_fill = PatternFill(start_color=styles['table_name']['fill']['color'], fill_type='solid')
     col_name_fill = PatternFill(start_color='F2F2F2', fill_type='solid')
 
     num_header_rows = 2

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -28,7 +28,7 @@ def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any
         yield from ws.iter_rows(values_only=True)
 
 
-def write_excel_openpyxl(tables, path, na_rep, style, num_blank_rows_between_tables):
+def write_excel_openpyxl(tables, path, na_rep, style, sep_lines):
     """Write tables to an Excel workbook at the specified path."""
 
     if not isinstance(tables, Dict):
@@ -50,16 +50,16 @@ def write_excel_openpyxl(tables, path, na_rep, style, num_blank_rows_between_tab
         for t in tabs:
             # Keep track of table dimensions for formatting as tuples (num rows, num cols, transposed)
             table_dimensions.append((len(t.df), len(t.df.columns), t.metadata.transposed))
-            _append_table_to_openpyxl_worksheet(t, ws, num_blank_rows_between_tables, na_rep)
+            _append_table_to_openpyxl_worksheet(t, ws, sep_lines, na_rep)
 
         if style:
-            _format_tables_in_worksheet(ws, table_dimensions, num_blank_rows_between_tables)
+            _format_tables_in_worksheet(ws, table_dimensions, sep_lines)
 
     wb.save(path)
 
 
 def _append_table_to_openpyxl_worksheet(
-    table: Table, ws: OpenpyxlWorksheet, num_blank_rows_between_tables: int, na_rep: str = "-"
+    table: Table, ws: OpenpyxlWorksheet, sep_lines: int, na_rep: str = "-"
 ) -> None:
     units = table.units
     if table.metadata.transposed:
@@ -79,12 +79,12 @@ def _append_table_to_openpyxl_worksheet(
             # TODO: apply format string specified in ColumnMetadata
             ws.append(_represent_row_elements(row, units, na_rep))
 
-    for _ in range(num_blank_rows_between_tables):
+    for _ in range(sep_lines):
         ws.append([])  # blank row marking table end
 
 
 def _format_tables_in_worksheet(
-        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], num_blank_rows_between_tables: int
+        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], sep_lines: int
 ) -> None:
     # Define styles to be used
     # TODO: These should perhaps live somewhere else?
@@ -122,7 +122,7 @@ def _format_tables_in_worksheet(
         _format_cells(name_cells, font=name_font, fill=variable_fill)
         _format_cells(unit_cells, fill=variable_fill)
 
-        i_start += true_num_rows + num_header_rows + num_blank_rows_between_tables
+        i_start += true_num_rows + num_header_rows + sep_lines
 
     # Widen columns
     max_num_cols = 0

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -204,6 +204,14 @@ def _style_tables_in_worksheet(
         _style_cells(column_unit_cells, styles.get("column_units"))
         _style_cells(chain.from_iterable(value_cells), styles.get("values"))  # flatten 2-D struct
 
+        # Special default case for transposed tables: center values and units
+        if transposed:
+            centered = {"alignment": {"horizontal": "center"}}
+            if not deep_get(styles, ["column_units", "alignment", "horizontal"]):
+                _style_cells(column_unit_cells, centered)
+            if not deep_get(styles, ["values", "alignment", "horizontal"]):
+                _style_cells(chain.from_iterable(value_cells), centered)
+
         i_start += true_num_rows + num_header_rows + sep_lines
 
     # Widen columns

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -25,7 +25,7 @@ DEFAULT_STYLE_SPEC = {
     },
     "destinations": {"font": {"color": "808080", "bold": True,}, "fill": {"color": "D9D9D9",},},
     "column_names": {"fill": {"color": "F2F2F2",}, "font": {"bold": True,},},
-    "column_units": {"fill": {"color": "F2F2F2",},},
+    "units": {"fill": {"color": "F2F2F2",},},
     "values": {},
 }
 
@@ -190,7 +190,7 @@ def _style_tables_in_worksheet(
             (table_name_cells, "table_name"),
             (destination_cells, "destinations"),
             (column_name_cells, "column_names"),
-            (column_unit_cells, "column_units"),
+            (column_unit_cells, "units"),
             (chain.from_iterable(value_cells), "values"),
         ]
         for cells, style_spec_name in style_spec_names:
@@ -202,7 +202,7 @@ def _style_tables_in_worksheet(
         # Special default case for transposed tables: center values and units
         if transposed:
             centered = {"alignment": {"horizontal": "center"}}
-            if not deep_get(styles, ["column_units", "alignment", "horizontal"]):
+            if not deep_get(styles, ["units", "alignment", "horizontal"]):
                 _style_cells(column_unit_cells, centered)
             if not deep_get(styles, ["values", "alignment", "horizontal"]):
                 _style_cells(chain.from_iterable(value_cells), centered)

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -17,6 +17,39 @@ from pdtable.io._represent import _represent_row_elements, _represent_col_elemen
 
 
 DEFAULT_SHEET_NAME = "Sheet1"
+DEFAULT_STYLE_SPEC = {
+        "table_name": {
+            "font": {
+                "color": "1F4E78",   # hex color code
+                "bold": True,
+            },
+            "fill": {
+                "color": "D9D9D9",  # RGB color code
+            },
+        },
+        "destinations": {
+            "font": {
+                "color": "808080",
+            },
+            "fill": {
+                "color": "888888",
+            },
+        },
+        "column_names": {
+            "fill": {
+                "color": "F2F2F2",
+            },
+            "font": {
+                "bold": True,
+            },
+        },
+        "column_units": {
+            "fill": {
+                "color": "F2F2F2",
+            },
+        },
+        "values": {},
+    }
 
 
 def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any]]:
@@ -53,7 +86,8 @@ def write_excel_openpyxl(tables, path, na_rep, style, sep_lines):
             _append_table_to_openpyxl_worksheet(t, ws, sep_lines, na_rep)
 
         if style:
-            _format_tables_in_worksheet(ws, table_dimensions, sep_lines)
+            style = DEFAULT_STYLE_SPEC if style is True else style
+            _format_tables_in_worksheet(ws, table_dimensions, style, sep_lines)
 
     wb.save(path)
 
@@ -84,15 +118,15 @@ def _append_table_to_openpyxl_worksheet(
 
 
 def _format_tables_in_worksheet(
-        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], sep_lines: int
+        ws: OpenpyxlWorksheet, table_dimensions: List[Tuple[int, int, bool]], style: Dict, sep_lines: int
 ) -> None:
     # Define styles to be used
-    # TODO: These should perhaps live somewhere else?
-    header_font = Font(bold=True, color='1F4E78')
-    destination_font = Font(bold=True, color='808080')
-    name_font = Font(bold=True)
-    header_fill = PatternFill(start_color='D9D9D9', fill_type='solid')
-    variable_fill = PatternFill(start_color='F2F2F2', fill_type='solid')
+    table_name_font = Font(bold=style['table_name']['font']['bold'], color=style['table_name']['font']['color'])
+    destination_font = Font(bold=style['destinations']['font']['bold'], color=style['destinations']['font']['color'])
+    col_name_font = Font(bold=style['column_names']['font']['bold'], color=style['column_names']['font']['color'])
+    # TODO deal with non-specified style elements!
+    table_name_fill = PatternFill(start_color=style['table_name']['fill']['color'], fill_type='solid')
+    col_name_fill = PatternFill(start_color='F2F2F2', fill_type='solid')
 
     num_header_rows = 2
     num_name_unit_rows = 2
@@ -117,10 +151,10 @@ def _format_tables_in_worksheet(
 
         header_row = table_rows[0]
         destination_row = table_rows[1]
-        _format_cells(header_row, font=header_font, fill=header_fill)
-        _format_cells(destination_row, font=destination_font, fill=header_fill)
-        _format_cells(name_cells, font=name_font, fill=variable_fill)
-        _format_cells(unit_cells, fill=variable_fill)
+        _format_cells(header_row, font=table_name_font, fill=table_name_fill)
+        _format_cells(destination_row, font=destination_font, fill=table_name_fill)
+        _format_cells(name_cells, font=col_name_font, fill=col_name_fill)
+        _format_cells(unit_cells, fill=col_name_fill)
 
         i_start += true_num_rows + num_header_rows + sep_lines
 

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -60,7 +60,7 @@ def write_excel(
     tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
     to: Union[str, os.PathLike, Path, BinaryIO],
     na_rep: str = "-",
-    num_blank_rows_between_tables: int = 1,
+    sep_lines: int = 1,
     style: bool = False
 ):
     """Writes one or more tables to an Excel workbook.
@@ -86,8 +86,8 @@ def write_excel(
             Optional; String representation of missing values (NaN, None, NaT).
             If overriding the default '-', it is recommended to use another value compliant with
             the StarTable standard.
-        num_blank_rows_between_tables:
-            Optional; Number of blank rows between tables.
+        sep_lines:
+            Optional; Number of blank separator lines between tables.
             Default is 1.
         style:
             Optional; Whether or not to apply standard StarTable style to Excel workbook file.
@@ -103,4 +103,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep, style, num_blank_rows_between_tables)
+    write_excel_func(tables, to, na_rep, style, sep_lines)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -61,7 +61,7 @@ def write_excel(
     to: Union[str, os.PathLike, Path, BinaryIO],
     na_rep: str = "-",
     sep_lines: int = 1,
-    style: bool = False
+    style: Union[bool, Dict] = False
 ):
     """Writes one or more tables to an Excel workbook.
 

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -77,21 +77,59 @@ def write_excel(
             * If a single Table or an iterable of Tables, writes to one sheet with default name.
             * If a dict of {sheet_name: Table} or {sheet_name: Iterable[Table]}, writes tables to
               sheets with specified names.
+
         to:
             File path or binary stream to which to write.
             If a file path, then this file gets created/overwritten and then closed after writing.
             If a stream, then it is left open after writing; the caller is responsible for managing
             the stream.
+
         na_rep:
             Optional; String representation of missing values (NaN, None, NaT).
             If overriding the default '-', it is recommended to use another value compliant with
             the StarTable standard.
+
         sep_lines:
             Optional; Number of blank separator lines between tables.
             Default is 1.
+
         styles:
-            Optional; Whether or not to apply standard StarTable styles to Excel workbook file.
-            Default is False.
+            Optional. Determines whether styles are applied to table blocks in the output workbook.
+            * If bool(styles) is False (default), no styles are applied.
+            * If True, default pdtable styles are applied (neutral shades of grey and dark blue).
+            * Custom styles can be specified by passing a JSON-like structure of dictionaries.
+              The top-level keys represent the parts of a table block and are any number of:
+              {'table_name', 'destinations', 'column_names', 'units', 'values'}
+              For each given table part, the value is a dictionary with any number of the following
+              style element keys: {'font', 'fill', 'alignment'}
+              The value for each of these keys is in turn a dictionary of valid {property: value}
+              pairs.
+              Example:
+                {
+                    'table_name': {
+                        'font': {'color': '1F4E78', 'bold': True,},
+                        'fill': {'color': 'D9D9D9',},  # RGB color code
+                    },
+                    'destinations': {
+                        'font': {'color': '808080', 'italic': True,},
+                        'fill': {'color': 'D9D9D9',},
+                    },
+                    'column_names': {
+                        'fill': {'color': 'F2F2F2',},
+                        'font': {'bold': True,},
+                    },
+                    'units': {'fill': {'color': 'F2F2F2',}},
+                    'values': {'alignment': {'horizontal': 'center'}},
+                }
+
+             Colors are given as RGB hex codes of the form 'RRGGBB' e.g. 'FF0000' is red.
+             Leading transparency digits are accepted but unused e.g. '42FF0000' will still be red.
+
+             If a table part key is omitted, then no style is applied to that table part.
+             Similarly, if a style element key is omitted, then no style is explicitly applied to
+             that style element.
+             In such cases, the default style is determined by the Excel writer engine (the default
+             engine is openpyxl).
     """
     try:
         from ._excel_openpyxl import write_excel_openpyxl as write_excel_func

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -61,7 +61,7 @@ def write_excel(
     to: Union[str, os.PathLike, Path, BinaryIO],
     na_rep: str = "-",
     sep_lines: int = 1,
-    style: Union[bool, Dict] = False
+    styles: Union[bool, Dict] = False
 ):
     """Writes one or more tables to an Excel workbook.
 
@@ -89,8 +89,8 @@ def write_excel(
         sep_lines:
             Optional; Number of blank separator lines between tables.
             Default is 1.
-        style:
-            Optional; Whether or not to apply standard StarTable style to Excel workbook file.
+        styles:
+            Optional; Whether or not to apply standard StarTable styles to Excel workbook file.
             Default is False.
     """
     try:
@@ -103,4 +103,4 @@ def write_excel(
             "Please install openpyxl for Excel I/O support."
         ) from err
 
-    write_excel_func(tables, to, na_rep, style, sep_lines)
+    write_excel_func(tables, to, na_rep, styles, sep_lines)

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -9,16 +9,17 @@ requiring them (read_excel() or write_excel()) are called for the first time.
 """
 import os
 from os import PathLike
+from pathlib import Path
 from typing import Union, Callable, Iterable, BinaryIO, Dict
 
 from .parsers.blocks import parse_blocks
 from .parsers.fixer import ParseFixer
-from .. import BlockType, Table, TableBundle
+from .. import BlockType, Table
 from ..store import BlockIterator
 
 
 def read_excel(
-    source: Union[str, PathLike, BinaryIO],
+    source: Union[str, PathLike, Path, BinaryIO],
     origin=None,
     fixer: ParseFixer = None,
     to: str = "pdtable",
@@ -57,7 +58,7 @@ def read_excel(
 
 def write_excel(
     tables: Union[Table, Iterable[Table], Dict[str, Table], Dict[str, Iterable[Table]]],
-    to: Union[str, os.PathLike, BinaryIO],
+    to: Union[str, os.PathLike, Path, BinaryIO],
     na_rep: str = "-",
     num_blank_rows_between_tables: int = 1,
     style: bool = False

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -291,11 +291,11 @@ def test_write_excel__custom_style(tmp_path):
             "font": {
                 "name": "Times New Roman",
                 "size": 24,
-                "color": "FF0000",   # hex color code
+                "color": "FF0000",   # RGB hex color code
                 "bold": True,
             },
             "fill": {
-                "color": "AAAAAA",
+                "color": "00AAAAAA",  # leading 'aa' transparency values are accepted (but unused)
             },
         },
         "destinations": {

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -11,7 +11,14 @@ except ImportError:
 
 from pdtable import Table
 from pdtable.io.excel import write_excel
-from pdtable.io._excel_openpyxl import _append_table_to_openpyxl_worksheet
+from pdtable.io._excel_openpyxl import _append_table_to_openpyxl_worksheet, deep_get
+
+
+def test_deep_get():
+    d = {'meta': {'status': 'OK', 'status_code': 200}}
+    assert deep_get(d, ['meta', 'status_code']) == 200
+    assert deep_get(d, ['garbage', 'status_code']) is None
+    assert deep_get(d, ['meta', 'garbage'], default='-') == '-'
 
 
 def test__append_table_to_openpyxl_worksheet():

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -142,7 +142,7 @@ def test_write_excel__multiple_sheets(tmp_path):
     out_path.unlink()
 
 
-def test_write_excel_with_formatting(tmp_path):
+def test_write_excel__style(tmp_path):
     # Make a couple of tables
     t = Table(name="foo")
     t["place"] = ["home", "work", "beach", "wonderland"]
@@ -269,7 +269,7 @@ def test_write_excel_with_formatting(tmp_path):
     out_path.unlink()
 
 
-def test_write_excel_with_formatting_and_2_blank_rows_between_tables(tmp_path):
+def test_write_excel__sep_lines(tmp_path):
     # Make a couple of tables
     t = Table(name="foo")
     t["place"] = ["home", "work", "beach", "wonderland"]
@@ -295,11 +295,11 @@ def test_write_excel_with_formatting_and_2_blank_rows_between_tables(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2, t3], out_path, style=True, sep_lines=2)
+    write_excel([t, t2, t3], out_path, sep_lines=2)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
-    # Tables are started as expected
+    # Tables start on the expected rows
     assert ws["A1"].value == "**foo"
     assert ws["A11"].value == "**bar*"
     assert ws["A17"].value == "**bas*"

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -296,7 +296,7 @@ def test_write_excel__custom_style(tmp_path):
                 "color": "#888888",
             },
         },
-        "col_names": {
+        "column_names": {
             "font": {
                 "color": "#444400",
                 "bold": True,
@@ -305,7 +305,7 @@ def test_write_excel__custom_style(tmp_path):
                 "color": "#777777",
             },
         },
-        "col_units": {
+        "column_units": {
             "font": {
                 "color": "#440044",
             },  # --------------------- fill unspecified, leave untouched

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -292,7 +292,7 @@ def test_write_excel__custom_style(tmp_path):
                 "bold": True,
             },
             "fill": {
-                "color": (200, 200, 255),  # RGB color code
+                "color": "AAAAAA",
             },
         },
         "destinations": {
@@ -317,11 +317,11 @@ def test_write_excel__custom_style(tmp_path):
                 "color": "440044",
             },  # --------------------- fill unspecified, leave untouched
         },
-        "values": {
-            "fill": {
-                "color": "EEEEEE",
-            },  # --------------------- font unspecified, leave untouched
-        },
+        # "values": {
+        #     "fill": {
+        #         "color": "EEEEEE",
+        #     },  # --------------------- font unspecified, leave untouched
+        # },
     }
 
     # Write tables to workbook, save, and re-load
@@ -333,7 +333,7 @@ def test_write_excel__custom_style(tmp_path):
     # Check table formatting
     # table name
     assert ws["A1"].fill.fill_type == "solid"
-    assert ws["A1"].fill.start_color.value == "00C8C8FF"  # correctly converted from RGB
+    assert ws["A1"].fill.start_color.value == "00AAAAAA"
     assert ws["A1"].font.color.value == "00FF0000"
     assert ws["A1"].font.bold is True
 
@@ -346,19 +346,20 @@ def test_write_excel__custom_style(tmp_path):
     # column names
     assert [ws.cell(3, c).fill.fill_type for c in range(1, nc+1)] == ["solid"] * nc
     assert [ws.cell(3, c).fill.start_color.value for c in range(1, nc+1)] == ["00777777"] * nc
-    assert [ws.cell(3, c).font.color.value for c in range(1, nc+1)] == "00444400"
+    assert [ws.cell(3, c).font.color.value for c in range(1, nc+1)] == ["00444400"] * nc
     assert [ws.cell(3, c).font.bold for c in range(1, nc+1)] == [True] * nc
 
     # column units
-    assert [ws.cell(4, c).fill.fill_type for c in range(1, nc+1)] == ["none"] * nc  # left as default
-    assert [ws.cell(4, c).font.color.value for c in range(1, nc+1)] == ["00777778"] * nc
+    assert [ws.cell(4, c).fill.fill_type for c in range(1, nc+1)] == [None] * nc  # left as default
+    assert [ws.cell(4, c).font.color.value for c in range(1, nc+1)] == ["00440044"] * nc
     assert [ws.cell(4, c).font.bold for c in range(1, nc+1)] == [False] * nc
 
+    # TODO style value cells
     # column values
-    assert [[ws.cell(4 + r, c).fill.fill_type for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
-    assert [[ws.cell(4 + r, c).fill.start_color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
-    assert [[ws.cell(4 + r, c).fill.color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00000000"] * nc] * nr
-    assert [[ws.cell(4 + r, c).fill.font.bold for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [[False] * nc] * nr
+    # assert [[ws.cell(4 + r, c).fill.fill_type for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
+    # assert [[ws.cell(4 + r, c).fill.start_color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
+    # assert [[ws.cell(4 + r, c).fill.color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00000000"] * nc] * nr
+    # assert [[ws.cell(4 + r, c).fill.font.bold for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [[False] * nc] * nr
 
 
 def test_write_excel__sep_lines(tmp_path):

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -281,7 +281,7 @@ def test_write_excel__custom_style(tmp_path):
     style_spec = {
         "table_name": {
             "font": {
-                "color": "#FF0000",   # hex color code
+                "color": "FF0000",   # hex color code
                 "bold": True,
             },
             "fill": {
@@ -290,29 +290,29 @@ def test_write_excel__custom_style(tmp_path):
         },
         "destinations": {
             "font": {
-                "color": "#0000FF",
+                "color": "0000FF",
             },
             "fill": {
-                "color": "#888888",
+                "color": "888888",
             },
         },
         "column_names": {
             "font": {
-                "color": "#444400",
+                "color": "444400",
                 "bold": True,
             },
             "fill": {
-                "color": "#777777",
+                "color": "777777",
             },
         },
         "column_units": {
             "font": {
-                "color": "#440044",
+                "color": "440044",
             },  # --------------------- fill unspecified, leave untouched
         },
         "values": {
             "fill": {
-                "color": "#EEEEEE",
+                "color": "EEEEEE",
             },  # --------------------- font unspecified, leave untouched
         },
     }

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -321,6 +321,9 @@ def test_write_excel__custom_style(tmp_path):
             },  # --------------------- fill unspecified, leave untouched
         },
         "values": {
+            "alignment": {
+                "horizontal": "center",
+            },
             "fill": {
                 "color": "EEEEEE",
             },  # --------------------- font unspecified, leave untouched
@@ -363,6 +366,7 @@ def test_write_excel__custom_style(tmp_path):
     # values
     assert [[ws.cell(4 + r, c).fill.fill_type for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
     assert [[ws.cell(4 + r, c).fill.start_color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00EEEEEE"] * nc] * nr
+    assert [[ws.cell(4 + r, c).alignment.horizontal for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["center"] * nc] * nr
     # assert [[ws.cell(4 + r, c).font.color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00EEEEEE"] * nc] * nr
     # assert [[ws.cell(4 + r, c).fill.font.bold for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [[False] * nc] * nr
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -288,6 +288,8 @@ def test_write_excel__custom_style(tmp_path):
     style_spec = {
         "table_name": {
             "font": {
+                "name": "Times New Roman",
+                "size": 24,
                 "color": "FF0000",   # hex color code
                 "bold": True,
             },
@@ -297,6 +299,7 @@ def test_write_excel__custom_style(tmp_path):
         },
         "destinations": {
             "font": {
+                "italic": True,
                 "color": "0000FF",
             },
             "fill": {
@@ -334,7 +337,9 @@ def test_write_excel__custom_style(tmp_path):
     # table name
     assert ws["A1"].fill.fill_type == "solid"
     assert ws["A1"].fill.start_color.value == "00AAAAAA"
+    assert ws["A1"].font.size == 24
     assert ws["A1"].font.color.value == "00FF0000"
+    assert ws["A1"].font.name == "Times New Roman"
     assert ws["A1"].font.bold is True
 
     # destinations
@@ -342,6 +347,7 @@ def test_write_excel__custom_style(tmp_path):
     assert ws["A2"].fill.start_color.value == "00888888"
     assert ws["A2"].font.color.value == "000000FF"
     assert ws["A2"].font.bold is False
+    assert ws["A2"].font.italic is True
 
     # column names
     assert [ws.cell(3, c).fill.fill_type for c in range(1, nc+1)] == ["solid"] * nc

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -30,7 +30,7 @@ def test__append_table_to_openpyxl_worksheet():
     ws = wb.active
 
     # Act
-    _append_table_to_openpyxl_worksheet(t, ws, num_blank_rows_between_tables=1)
+    _append_table_to_openpyxl_worksheet(t, ws, sep_lines=1)
 
     # Assert worksheet looks as expected:
     # table header by row
@@ -295,7 +295,7 @@ def test_write_excel_with_formatting_and_2_blank_rows_between_tables(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2, t3], out_path, style=True, num_blank_rows_between_tables=2)
+    write_excel([t, t2, t3], out_path, style=True, sep_lines=2)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -317,11 +317,11 @@ def test_write_excel__custom_style(tmp_path):
                 "color": "440044",
             },  # --------------------- fill unspecified, leave untouched
         },
-        # "values": {
-        #     "fill": {
-        #         "color": "EEEEEE",
-        #     },  # --------------------- font unspecified, leave untouched
-        # },
+        "values": {
+            "fill": {
+                "color": "EEEEEE",
+            },  # --------------------- font unspecified, leave untouched
+        },
     }
 
     # Write tables to workbook, save, and re-load
@@ -354,11 +354,10 @@ def test_write_excel__custom_style(tmp_path):
     assert [ws.cell(4, c).font.color.value for c in range(1, nc+1)] == ["00440044"] * nc
     assert [ws.cell(4, c).font.bold for c in range(1, nc+1)] == [False] * nc
 
-    # TODO style value cells
-    # column values
-    # assert [[ws.cell(4 + r, c).fill.fill_type for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
-    # assert [[ws.cell(4 + r, c).fill.start_color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
-    # assert [[ws.cell(4 + r, c).fill.color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00000000"] * nc] * nr
+    # values
+    assert [[ws.cell(4 + r, c).fill.fill_type for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["solid"] * nc] * nr
+    assert [[ws.cell(4 + r, c).fill.start_color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00EEEEEE"] * nc] * nr
+    # assert [[ws.cell(4 + r, c).font.color.value for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["00EEEEEE"] * nc] * nr
     # assert [[ws.cell(4 + r, c).fill.font.bold for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [[False] * nc] * nr
 
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -168,7 +168,7 @@ def test_write_excel__style(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo.xlsx"
-    write_excel([t, t2, t3], out_path, style=True)
+    write_excel([t, t2, t3], out_path, styles=True)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
@@ -319,7 +319,7 @@ def test_write_excel__custom_style(tmp_path):
 
     # Write tables to workbook, save, and re-load
     out_path = tmp_path / "foo_custom_style.xlsx"
-    write_excel([t], out_path, style=style_spec)
+    write_excel([t], out_path, styles=style_spec)
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 
@@ -396,7 +396,7 @@ def test_read_write_excel__round_trip_with_styles(tmp_path):
     bundle = TableBundle(read_excel("pdtable/test/io/input/foo.xlsx"))
     out_path = tmp_path / "foo_styled.xlsx"
     # Doesn't crash on write
-    write_excel(bundle, out_path, style=True)
+    write_excel(bundle, out_path, styles=True)
     # Re-read bundle is same as first one
     bundle2 = TableBundle(read_excel(out_path))
     for t, t2 in zip(bundle, bundle2):

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -316,7 +316,7 @@ def test_write_excel__custom_style(tmp_path):
                 "color": "777777",
             },
         },
-        "column_units": {
+        "units": {
             "font": {
                 "color": "440044",
             },  # --------------------- fill unspecified, leave untouched
@@ -415,7 +415,7 @@ def test_write_excel__transposed_table_units_and_values_are_centered_by_default(
     # Write tables to workbook with custom alignment styles, save, and re-load
     out_path = tmp_path / "foo_custom_style.xlsx"
     left = {"alignment": {"horizontal": "left"}}
-    write_excel([t], out_path, styles={"column_units": left, "values": left})  # << Custom alignment
+    write_excel([t], out_path, styles={"units": left, "values": left})  # << Custom alignment
     wb = openpyxl.load_workbook(out_path)
     ws = wb.active
 

--- a/pdtable/test/io/test__excel.py
+++ b/pdtable/test/io/test__excel.py
@@ -379,7 +379,7 @@ def test_write_excel__transposed_table_units_and_values_are_centered_by_default(
     nc = len(t.column_names)
     nr = len(t.df)
 
-    # DEFAULT: CENTERED
+    # DEFAULT ALIGNMENT: CENTER
     # Write tables to workbook with default styles, save, and re-load
     out_path = tmp_path / "foo_custom_style.xlsx"
     write_excel([t], out_path, styles=True)  # <<< Default style
@@ -390,7 +390,7 @@ def test_write_excel__transposed_table_units_and_values_are_centered_by_default(
     assert [ws.cell(2 + c, 2).alignment.horizontal for c in range(1, nc+1)] == ["center"] * nc
     assert [[ws.cell(2 + c, 2 + r).alignment.horizontal for c in range(1, nc + 1)] for r in range(1, nr + 1)] == [["center"] * nc] * nr
 
-    # DEFAULT NOT APPLIED when custom alignment is specified
+    # DEFAULT ALIGNMENT NOT APPLIED when custom alignment is specified
     # Write tables to workbook with custom alignment styles, save, and re-load
     out_path = tmp_path / "foo_custom_style.xlsx"
     left = {"alignment": {"horizontal": "left"}}


### PR DESCRIPTION
Can now optionally specify custom styles in `write_excel()` by passing to parameter `styles` a JSON-like structure of dicts! (#96)

Also, when `write_excel()` parameter `styles` is truthy (i.e. either `True` or a custom dict), transposed tables' column units and values get horizontally centered by default (#97). This default is overridden by any horizontal alignment specified explicitly in `styles`. 

This is all demo'ed in the tests.

Other changes of note:
- `write_excel()` parameter `style` renamed to `styles` because really it's five different styles for each of {tablename, destination, column names, column units, values}, and it makes for a more convenient namespace internally 
- `write_excel()` parameter `num_blank_rows_between_tables` renamed to `sep_lines` for conciseness.