### PR TITLE
Feature/table origin

### DIFF
--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -9,30 +9,21 @@
 @startuml Table Origin
 
 namespace load {
+    class LoadIssue {
+        load_item: LoadItem,
+        location_file: None | LocationFile,
+        location: None | LocationBlock,
+        issue: str | Exception
+    }
+
     interface LoadOrchestrator {
         + add_load_item(spec: LoadItem)
+        + register_load_issue(load_issue)
     }
-    note top
-        Separate orchestrator allows
-        plugable multithreaded load
-    end note
 
     interface Loader {
         + load(LoadItem, LoadOrchestrator) -> Iterator[Block]
     }
-    note top
-        Not just a callable, to allow state.
-        State could inlude db connection,
-        project root folder, cache folder,
-    end note
-
-    class ProtocolOrchestrator {
-        + default_protocol: str
-        + load_by_protocol: Dict[str, Loader]
-        + load_from_root_specs([str]) -> Iterator[Block]
-    }
-
-    LoadOrchestrator <|-- ProtocolOrchestrator
 }
 
 namespace table {
@@ -49,29 +40,35 @@ namespace table {
 namespace table_origin {
     class LoadItem  {
         specification: str
-        included_from: LoadLocation
-        __str__ -> heritage
+        source: None | LoadLocation
+        load_history() -> [LoadItem]
     }
 
     class LocationFolder {
         + local_folder_path: Path
+        + load_specification: LoadItem
     }
 
     LoadItem o-- LoadLocation
     LoadLocation <|-- LocationBlock
     LoadLocation <|-- LocationFolder
 
+    LoadItem --o LocationFolder
+
     interface LoadLocation {
         + local_folder_path: None | Path
+        + load_identifier: str
         + open_interactive(read_only)
     }
 
     interface LocationFile {
-    + file_specification: LoadItem 
-    + file_metadata: Any  # record metadata, modtime,...
-    + open_interactive(sheet, row, read_only)  # may fail
-    + local_path: None | Path
-    + get_local_path(): Path # downloads if required
+        + load_specification: LoadItem 
+        + load_identifier: str # unique
+        + load_metadata: Any  # record metadata, modtime,...
+        + open_interactive(sheet, row, read_only)  # may fail
+        + local_path: None | Path
+        + local_folder_path: None | Path
+        + get_local_path(): Path # downloads if required
     }
 
     LoadItem  -o LocationFile
@@ -91,19 +88,13 @@ namespace table_origin {
 
 
     interface TableOrigin {
+        input_location: LocationBlock | None
         parents: [TableOrigin]
-        concrete_ancestors: [ConcreteTableOrigin]
         operation: str | None
+        input_ancestors: [LocationBlock]
     }
 
-    class ConcreteTableOrigin {
-        origin: LocationBlock
-    }
-
-    TableOrigin <|-- ConcreteTableOrigin
-    TableOrigin <|-- SyntheticTableOrigin
-
-    LocationBlock -* ConcreteTableOrigin
+    LocationBlock -* TableOrigin
 }
 
 @enduml

--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -1,0 +1,109 @@
+     def resolve(specificaton: str, orchestrator: Orchestrator, included_from: Optional[Location])
+     	   # spec may not be unique: it can be relative to included_from
+          if identifier is folder:
+               for file in folder.glob(pattern):
+                   orchestrator.add_source(file, identifier->location)
+          else:
+          	file_metadata, generator = handlers[identifier->protocol].read(identifier)
+
+@startuml Table Origin
+
+namespace load {
+    interface LoadOrchestrator {
+        + add_load_item(spec: LoadItem)
+    }
+    note top
+        Separate orchestrator allows
+        plugable multithreaded load
+    end note
+
+    interface Loader {
+        + load(LoadItem, LoadOrchestrator) -> Iterator[Block]
+    }
+    note top
+        Not just a callable, to allow state.
+        State could inlude db connection,
+        project root folder, cache folder,
+    end note
+
+    class ProtocolOrchestrator {
+        + default_protocol: str
+        + load_by_protocol: Dict[str, Loader]
+        + load_from_root_specs([str]) -> Iterator[Block]
+    }
+
+    LoadOrchestrator <|-- ProtocolOrchestrator
+}
+
+namespace table {
+    class TableMetadata {
+        + name
+        + destinations
+        + transposed
+        + origin: TableOrigin
+
+    }
+    table_origin.TableOrigin -o TableMetadata
+}
+
+namespace table_origin {
+    class LoadItem  {
+        specification: str
+        included_from: LoadLocation
+        __str__ -> heritage
+    }
+
+    class LocationFolder {
+        + local_folder_path: Path
+    }
+
+    LoadItem o-- LoadLocation
+    LoadLocation <|-- LocationBlock
+    LoadLocation <|-- LocationFolder
+
+    interface LoadLocation {
+        + local_folder_path: None | Path
+        + open_interactive(read_only)
+    }
+
+    interface LocationFile {
+    + file_specification: LoadItem 
+    + file_metadata: Any  # record metadata, modtime,...
+    + open_interactive(sheet, row, read_only)  # may fail
+    + local_path: None | Path
+    + get_local_path(): Path # downloads if required
+    }
+
+    LoadItem  -o LocationFile
+
+    class LocationSheet {
+    + sheet_name: None | str
+    + sheet_metadata: Any
+    }
+
+    LocationFile --o "file" LocationSheet
+
+    class LocationBlock {
+    + row: int
+    }
+
+    LocationSheet --o "sheet" LocationBlock
+
+
+    interface TableOrigin {
+        parents: [TableOrigin]
+        concrete_ancestors: [ConcreteTableOrigin]
+        operation: str | None
+    }
+
+    class ConcreteTableOrigin {
+        origin: LocationBlock
+    }
+
+    TableOrigin <|-- ConcreteTableOrigin
+    TableOrigin <|-- SyntheticTableOrigin
+
+    LocationBlock -* ConcreteTableOrigin
+}
+
+@enduml

--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -58,17 +58,20 @@ namespace table_origin {
     interface LoadLocation {
         + local_folder_path: None | Path
         + load_identifier: str
-        + open_interactive(read_only)
+        + interactive_open(read_only)
+        + interactive_uri(read_only)
+        + interactive_identifier: str
     }
 
     interface LocationFile {
         + load_specification: LoadItem 
         + load_identifier: str # unique
-        + load_metadata: Any  # record metadata, modtime,...
-        + open_interactive(sheet, row, read_only)  # may fail
         + local_path: None | Path
         + local_folder_path: None | Path
         + get_local_path(): Path # downloads if required
+        + interactive_open(sheet, row, read_only)  # may fail
+        + interactive_uri(sheet, row, read_only): URI
+        + interactive_identifier: str 
     }
 
     LoadItem  -o LocationFile
@@ -87,11 +90,11 @@ namespace table_origin {
     LocationSheet --o "sheet" LocationBlock
 
 
-    interface TableOrigin {
+    class TableOrigin {
         input_location: LocationBlock | None
         parents: [TableOrigin]
         operation: str | None
-        input_ancestors: [LocationBlock]
+        get_input_ancestors(): [LocationBlock]
     }
 
     LocationBlock -* TableOrigin

--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -42,9 +42,9 @@ namespace table_origin {
         + local_folder_path: None | Path
         + load_specification: LoadItem
         + load_identifier: str
+        + interactive_identifier: str
         + interactive_open(read_only)
         + interactive_uri(read_only)
-        + interactive_identifier: str
     }
 
     interface LocationFile {
@@ -60,7 +60,7 @@ namespace table_origin {
 
     LocationFile <|-- FileSystemLocationFile
     LocationFile <|-- NullLocationFile
-    
+    LocationFile --|> LoadLocation
 
     LoadItem  -o LocationFile
 

--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -9,16 +9,9 @@
 @startuml Table Origin
 
 namespace load {
-    class LoadIssue {
-        load_item: LoadItem,
-        location_file: None | LocationFile,
-        location: None | LocationBlock,
-        issue: str | Exception
-    }
-
     interface LoadOrchestrator {
         + add_load_item(spec: LoadItem)
-        + register_load_issue(load_issue)
+        + issue_tracker
     }
 
     interface Loader {
@@ -98,6 +91,21 @@ namespace table_origin {
     }
 
     LocationBlock -* TableOrigin
+
+    class InputIssue {
+        load_item: LoadItem,
+        location_file: None | LocationFile,
+        origin: None | TableOrigin,
+        issue: str | Exception
+    }
+
+    interface InputIssueTracker {
+        add_issue(input_issue)
+        is_ok: bool
+        issues: Iterable[InputIssue]
+    }
+
+    InputIssue <-- InputIssueTracker
 }
 
 @enduml

--- a/docs/diagrams/src/table_origin.puml
+++ b/docs/diagrams/src/table_origin.puml
@@ -19,16 +19,6 @@ namespace load {
     }
 }
 
-namespace table {
-    class TableMetadata {
-        + name
-        + destinations
-        + transposed
-        + origin: TableOrigin
-
-    }
-    table_origin.TableOrigin -o TableMetadata
-}
 
 namespace table_origin {
     class LoadItem  {
@@ -50,6 +40,7 @@ namespace table_origin {
 
     interface LoadLocation {
         + local_folder_path: None | Path
+        + load_specification: LoadItem
         + load_identifier: str
         + interactive_open(read_only)
         + interactive_uri(read_only)
@@ -66,6 +57,10 @@ namespace table_origin {
         + interactive_uri(sheet, row, read_only): URI
         + interactive_identifier: str 
     }
+
+    LocationFile <|-- FileSystemLocationFile
+    LocationFile <|-- NullLocationFile
+    
 
     LoadItem  -o LocationFile
 
@@ -106,6 +101,9 @@ namespace table_origin {
     }
 
     InputIssue <-- InputIssueTracker
+
+    InputIssueTracker <|-- NullInputIssueTracker
 }
+
 
 @enduml

--- a/pdtable/__init__.py
+++ b/pdtable/__init__.py
@@ -13,3 +13,5 @@ from .io import ParseFixer
 from .io import read_csv, write_csv
 from .io import read_excel, write_excel
 from .units.pint import PintUnitConverter, pint_converter
+from .io.load import load_files
+

--- a/pdtable/frame.py
+++ b/pdtable/frame.py
@@ -108,7 +108,7 @@ def _combine_tables(
     )
     meta = TableMetadata(
         name=data[0].metadata.name,
-        destinations=data[0].destinations,
+        destinations=data[0].metadata.destinations,
         origin=origin,
     )
 

--- a/pdtable/frame.py
+++ b/pdtable/frame.py
@@ -54,6 +54,7 @@ import warnings
 from typing import Set, Dict, Optional, Iterable
 
 from .table_metadata import TableMetadata, ColumnMetadata, ComplementaryTableInfo
+from .table_origin import TableOrigin
 
 _TABLE_INFO_FIELD_NAME = "_table_data"
 
@@ -101,8 +102,14 @@ def _combine_tables(
         return None
 
     # 1: Create table metadata as combination of all
+    origin = TableOrigin(
+        operation=f"Pandas {method}", 
+        parents=[d.metadata.origin for d in data]
+    )
     meta = TableMetadata(
-        name=data[0].metadata.name, operation=f"Pandas {method}", parents=[d.metadata for d in data]
+        name=data[0].metadata.name,
+        destinations=data[0].destinations,
+        origin=origin,
     )
 
     # 2: Check that units match for columns that appear in more than one table

--- a/pdtable/io/_excel_openpyxl.py
+++ b/pdtable/io/_excel_openpyxl.py
@@ -2,7 +2,7 @@
 from itertools import chain
 from os import PathLike
 from typing import Union, Iterable, Sequence, Any, Dict, List, Tuple, Optional
-
+from contextlib import closing
 import openpyxl
 
 try:
@@ -32,11 +32,17 @@ DEFAULT_STYLE_SPEC = {
 
 def read_cell_rows_openpyxl(path: Union[str, PathLike]) -> Iterable[Sequence[Any]]:
     """Reads from an Excel workbook, yielding one row of cells at a time."""
-    import openpyxl
 
-    wb = openpyxl.load_workbook(path, read_only=True, data_only=True, keep_links=False)
-    for ws in wb.worksheets:
-        yield from ws.iter_rows(values_only=True)
+    with closing(openpyxl.load_workbook(path, read_only=True, data_only=True, keep_links=False)) as wb:
+        for ws in wb.worksheets:
+            yield from ws.iter_rows(values_only=True)
+
+def read_sheets(path: Union[str, PathLike]) -> Iterable[Tuple[str, Iterable[Sequence[Any]]]]:
+    """Reads from an Excel workbook, yielding (sheet_name, <row iterator>)."""
+
+    with closing(openpyxl.load_workbook(path, read_only=True, data_only=True, keep_links=False)) as wb:
+        for ws in wb.worksheets:
+            yield   (ws.title, ws.iter_rows(values_only=True))
 
 
 def write_excel_openpyxl(tables, path, na_rep, styles, sep_lines):

--- a/pdtable/io/_json.py
+++ b/pdtable/io/_json.py
@@ -5,8 +5,6 @@ from typing import Union, Dict, List
 
 import numpy as np
 
-from pdtable.table_metadata import TableOriginCSV
-
 # Typing alias:
 # JSON-like data structure of nested dicts ("objects"), lists ("arrays"), and JSON-native values
 JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, float, int, bool, None]
@@ -21,7 +19,6 @@ JsonDataPrecursor = Union[
     bool,
     None,
     datetime.datetime,
-    TableOriginCSV,
 ]
 
 _json_encodable_value_maps = {
@@ -59,9 +56,6 @@ def to_json_serializable(obj: JsonDataPrecursor) -> JsonData:
             # Note: would fail for obj.ndim > 1, but this is never the case here (columns are 1 dim)
         else:
             return [to_json_serializable(val) for val in obj.tolist()]
-
-    if isinstance(obj, TableOriginCSV):
-        return str(obj._file_name)
 
     if isinstance(obj, datetime.datetime):
         jval = str(obj)

--- a/pdtable/io/csv.py
+++ b/pdtable/io/csv.py
@@ -13,12 +13,14 @@ from .. import BlockType, Table, TableBundle
 from ..store import BlockIterator
 from .parsers.fixer import ParseFixer
 from .parsers.blocks import parse_blocks
+from ..table_origin import LocationSheet, NullLocationFile
 
 
 def read_csv(
     source: Union[str, PathLike, TextIO],
     sep: str = None,
     origin: str = None,
+    location_sheet: LocationSheet = None,
     fixer: ParseFixer = None,
     to: str = "pdtable",
     filter: Callable[[BlockType, str], bool] = None,
@@ -84,13 +86,15 @@ def read_csv(
     if sep is None:
         sep = pdtable.CSV_SEP
 
-    if origin is None:
-        if hasattr(source, "name"):
-            origin = source.name
-        else:
-            origin = str(source)
+    if location_sheet is None:
+        if origin is None:
+            if hasattr(source, "name"):
+                origin = source.name
+            else:
+                origin = str(source)
+        location_sheet = NullLocationFile(load_identifier=origin).make_location_sheet()
 
-    kwargs = {"sep": sep, "origin": origin, "fixer": fixer, "to": to, "filter": filter}
+    kwargs = {"sep": sep, "location_sheet": location_sheet, "fixer": fixer, "to": to, "filter": filter}
 
     if not isinstance(source, (str, PathLike)):
         assert isinstance(source, io.TextIOBase)

--- a/pdtable/io/csv.py
+++ b/pdtable/io/csv.py
@@ -65,7 +65,7 @@ def read_csv(
             Optional; CSV field delimiter. Default is ';'.
 
         origin:
-            Optional; Table location. May be shadowed by `location_sheet`.
+            Optional; File origin description/file name as str. May be shadowed by `location_sheet`.
 
         location_sheet:
             Optional; Origin of sheet as a LocationSheet object.
@@ -103,7 +103,7 @@ def read_csv(
         if not source_is_stream:
             location_sheet = FilesystemLocationFile(local_path=source, load_specification=origin).make_location_sheet()
         elif origin is not None:
-            location_sheet = NullLocationFile(origin).make_location_sheet()
+            location_sheet = NullLocationFile(str(origin)).make_location_sheet()
         # else: keep location_sheet undefined
     elif origin is not None:
         warnings.warn(f"Input 'origin': {origin} is shadowed by input 'location_sheet': {location_sheet}.")

--- a/pdtable/io/csv.py
+++ b/pdtable/io/csv.py
@@ -4,8 +4,10 @@ import io
 from contextlib import nullcontext
 from itertools import chain
 from os import PathLike
-
+from re import I
+import warnings
 from typing import TextIO, Union, Callable, Iterable
+from pathlib import Path
 
 import pdtable  # Required to read dynamically-set pdtable.CSV_SEP
 from ._represent import _represent_row_elements, _represent_col_elements
@@ -13,17 +15,19 @@ from .. import BlockType, Table, TableBundle
 from ..store import BlockIterator
 from .parsers.fixer import ParseFixer
 from .parsers.blocks import parse_blocks
-from ..table_origin import LocationSheet, NullLocationFile
+from ..table_origin import FilesystemLocationFile, InputIssueTracker, LocationSheet, NullLocationFile
 
 
 def read_csv(
     source: Union[str, PathLike, TextIO],
     sep: str = None,
+    *, 
     origin: str = None,
     location_sheet: LocationSheet = None,
     fixer: ParseFixer = None,
     to: str = "pdtable",
     filter: Callable[[BlockType, str], bool] = None,
+    issue_tracker: InputIssueTracker = None,
 ) -> BlockIterator:
     """Reads StarTable data from a CSV file or text stream, yielding one block at a time.
 
@@ -61,7 +65,13 @@ def read_csv(
             Optional; CSV field delimiter. Default is ';'.
 
         origin:
-            Optional; Table location
+            Optional; Table location. May be shadowed by `location_sheet`.
+
+        location_sheet:
+            Optional; Origin of sheet as a LocationSheet object.
+            `location_sheet` takes precedence over `origin`. For file input default
+            if input path with `origin` as optional input specification, for stream input
+            default is a null context with `origin` as description.
 
         fixer:
             Customized ParseFixer instance to be used instead of default fixer.
@@ -81,27 +91,30 @@ def read_csv(
     Yields:
         Tuples of (BlockType, block) where 'block' is one of {Table, MetadataBlock, Directive,
         TemplateBlock}
-
     """
+    
+    # handle heterogeneous input source
+    source_is_stream = hasattr(source, "readline")
+    if not source_is_stream:
+        source = Path(source)
+
+    # resolve location_sheet
+    if location_sheet is None:
+        if not source_is_stream:
+            location_sheet = FilesystemLocationFile(local_path=source, load_specification=origin).make_location_sheet()
+        elif origin is not None:
+            location_sheet = NullLocationFile(origin).make_location_sheet()
+        # else: keep location_sheet undefined
+    elif origin is not None:
+        warnings.warn(f"Input 'origin': {origin} is shadowed by input 'location_sheet': {location_sheet}.")
+
     if sep is None:
         sep = pdtable.CSV_SEP
 
-    if location_sheet is None:
-        if origin is None:
-            if hasattr(source, "name"):
-                origin = source.name
-            else:
-                origin = str(source)
-        location_sheet = NullLocationFile(load_identifier=origin).make_location_sheet()
-
-    kwargs = {"sep": sep, "location_sheet": location_sheet, "fixer": fixer, "to": to, "filter": filter}
-
-    if not isinstance(source, (str, PathLike)):
-        assert isinstance(source, io.TextIOBase)
-
-    with open(source) if isinstance(source, (str, PathLike)) else nullcontext(source) as f:
+    with nullcontext(source) if source_is_stream else open(source) as f:
         cell_rows = (line.rstrip("\n").split(sep) for line in f)
-        yield from parse_blocks(cell_rows, **kwargs)
+        yield from parse_blocks(cell_rows, location_sheet=location_sheet, 
+                                fixer=fixer, to=to, filter=filter, issue_tracker=issue_tracker)
 
 
 def write_csv(

--- a/pdtable/io/load.py
+++ b/pdtable/io/load.py
@@ -1,0 +1,242 @@
+from pdtable.table_origin import LocationFolder
+from pdtable.store import BlockIterator, BlockType
+from typing import (
+    Protocol,
+    Iterator,
+    Any,
+    NamedTuple,
+    Iterable,
+    Optional,
+    Set,
+    Tuple,
+    Callable,
+    List,
+)
+from abc import abstractmethod, abstractstaticmethod
+import logging, time
+from dataclasses import dataclass, field
+from pathlib import Path, PosixPath
+import sys, os, subprocess, logging, re
+import datetime
+
+from ..table_origin import LocationFile, LocationBlock, LoadItem, TableOrigin
+
+logger = logging.getLogger(__name__)
+
+
+class LoadIssuesError(Exception):
+    def __init__(self, issues):
+        self.issues = issues
+
+
+class LoadError(Exception):
+    pass
+
+
+# Todo: integrate properly with origin
+class LoadIssue(NamedTuple):
+    load_item: Optional[LoadItem] = None
+    location_file: Optional[LocationFile] = None
+    location: Optional[LocationBlock] = None
+    issue: Any = None
+
+
+class LoadOrchestrator(Protocol):
+    @abstractmethod
+    def add_load_item(self, w: LoadItem):
+        pass
+
+    @abstractmethod
+    def register_load_issue(self, load_issue: LoadIssue):
+        pass
+
+
+class Loader(Protocol):
+    @abstractmethod
+    def load(self, load_item: LoadItem, orchestrator: LoadOrchestrator) -> BlockIterator:
+        pass
+
+
+### FilesystemLoder et al.
+
+
+class FilesystemLocationFile(LocationFile):
+    def __init__(
+        self, local_path: Path, load_specification: Optional[LoadItem] = None, stat_result=None
+    ) -> None:
+        self._local_path = local_path
+        self._load_specification = load_specification or LoadItem(
+            specification=str(local_path), source=None
+        )
+        self._stat_result = stat_result
+
+    @property
+    def local_path(self):
+        return self._local_path
+
+    @property
+    def load_specification(self) -> LoadItem:
+        return self._load_specification
+
+    def get_stat_result(self, cached=True):
+        if (not cached) or self._stat_result is None:
+            self._stat_result = self.local_path.stat()
+        return self._stat_result
+
+    def get_mtime(self) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(self.get_stat_result().st_mtime)
+
+    @property
+    def load_identifier(self) -> str:
+        name_part = str(self.local_path.absolute())
+        mtime = self.get_mtime()
+        if mtime:
+            return name_part + "@" + mtime.isoformat(timespec="seconds")
+        return name_part
+
+    @property
+    def interactive_identifier(self) -> str:
+        return str(self.local_path)
+
+    def get_interactive_identifier(
+        self, sheet: Optional[str] = None, row: Optional[int] = None
+    ) -> str:
+        if sheet is None:
+            loc = f"Row {row}"
+        else:
+            loc = f"'{sheet}'!A{row}"
+        return f"{loc} of '{self.interactive_identifier}'"
+
+    def interactive_uri(
+        self,
+        sheet: Optional[str] = None,
+        row: Optional[int] = None,
+        read_only: Optional[bool] = False,
+    ) -> str:
+        file_uri = self.local_path.as_uri()
+        if sheet is None and row is None:
+            return file_uri
+        if sheet is None:
+            sheet = "Sheet1"
+        row_mark = f"!A{row}" if row is not None else ""
+        return file_uri + f"#'{sheet}'{row_mark}"
+
+
+class LoadResolver(Protocol):
+    @abstractmethod
+    def resolve(spec_without_protocol) -> Tuple[bool, LocationFile]:
+        pass
+
+
+Reader = Callable[[LocationFile, LoadOrchestrator], BlockIterator]
+
+_ABSOLUTE_PATH = re.compile(r"/|\\")
+
+
+@dataclass(frozen=True)
+class FilesystemLoader(Loader):
+    """
+    A Loader implementation for local filesystem loads
+
+    Implementation of ``***include``-directive
+    ------------------------------------------
+    Each row in an include directive correspond to a load item. 
+    Paths are resolved as follows:
+    - relative paths are resolved relative to the file they are specified in
+    - absolute paths are resolved relative to the root folder
+
+
+
+    ``file_name_pattern``
+    ---------------------
+    When a directory is a directory, files matching this pattern will be loaded.
+
+
+    ``ignore_protocol``
+    -------------------
+    ``specification`` field in ``LoadItem`` instances may optionally include protocol-specification.
+    This protocol should match value of ``ignore_protocol``, which defaults to ``file:``. Set value
+    of of ``ignore_protocol`` to ``None`` to not accept any protocol in specificaton string.
+    """
+
+    file_reader: Reader
+    root_folder: Path
+    file_name_pattern: re.Pattern = field(
+        default_factory=lambda: re.compile(r"^(input|setup)_.*\.(csv|xls|xlsx)$")
+    )
+    ignore_protocol: Optional[str] = "file:"
+
+    def resolve_load_item_path(self, load_item: LoadItem) -> Path:
+        spec = load_item.specification
+        if self.ignore_protocol and spec.startswith(self.ignore_protocol):
+            spec = spec[len(self.ignore_protocol) :]
+        is_absolute = _ABSOLUTE_PATH.match(spec) is not None
+        if is_absolute:
+            resolved = self.root_folder / spec[1:]
+        else:
+            if load_item.source is None or load_item.source.local_folder_path is None:
+                raise LoadError("Cannot load location relative to source with no local folder path")
+            resolved = load_item.source.local_folder_path / spec
+        resolved = resolved.resolve()
+        try:
+            resolved_relative = resolved.relative_to(self.root_folder)
+        except ValueError as e:
+            raise LoadError(f"Load item {resolved} is outside load root folder: {self.root_folder}")
+
+        return resolved
+
+    def load(self, load_item: LoadItem, orchestrator: LoadOrchestrator) -> BlockIterator:
+        full_path = self.resolve_load_item_path(load_item)
+        if full_path.is_dir():
+            src = LocationFolder(local_folder_path=full_path, load_specification=load_item)
+            yield from self.load_folder(src, orchestrator)
+        else:
+            src = FilesystemLocationFile(local_path=full_path, load_specification=load_item)
+            yield from self.load_file(src, orchestrator)
+
+    def load_folder(
+        self, location: LocationFolder, orchestrator: LoadOrchestrator
+    ) -> BlockIterator:
+        for p in location.local_folder_path.iterdir():
+            if not self.file_name_pattern.match(p.name):
+                continue
+            logger.debug(f"Including file '{p}' from '{location}'")
+            orchestrator.add_load_item(LoadItem(specification=p.name, source=location))
+        return
+        yield  # to ensure this is a generator
+
+    def load_file(self, location: LocationFile, orchestrator: LoadOrchestrator) -> BlockIterator:
+        if location.local_path is None:
+            raise ValueError("FilesystemLoader only supports local files")
+        for block_type, value in self.file_reader(location, orchestrator):
+            if block_type == BlockType.DIRECTIVE and value.name == "include":
+                source = value.origin.input_location
+                for line in value.lines:
+                    logger.debug(f"Adding include '{line}' from {source.interactive_identifier}")
+                    orchestrator.add_load_item(LoadItem(specification=line, source=source))
+            else:
+                yield block_type, value
+
+
+### SimpleOrchestrator
+
+
+def load_all(roots: List[LoadItem], loader: Loader):
+    class Orchestrator:
+        def __init__(self, roots):
+            self.load_items = roots
+            self.issues = []
+
+        def add_load_item(self, item):
+            self.load_items.append(item)
+
+        def register_load_issue(self, issue):
+            self.issues.append(issue)
+
+    orch = Orchestrator(roots)
+    while orch.load_items:
+        yield from loader.load(orch.load_items.pop(), orch)
+
+    if orch.issues:
+        raise LoadError(f"Load issues: {orch.issues}")
+

--- a/pdtable/io/load.py
+++ b/pdtable/io/load.py
@@ -1,3 +1,25 @@
+"""
+The ``load``-module is responsible for reading input sets
+
+Compared to the single-file reader functions, the load functionality adds:
+
+  - Support of `***include` directives
+  - Support for multiple input sources (records systems, blobs, etc)
+  - Support of tracking input origin 
+
+
+Example of loading all files in a given folder::
+
+    inputs = load_files(['/'], root_folder=root_folder, csv_sep=';')
+    bundle =  TableBundle(inputs)
+
+The Table objects returned by load will have an `origin` attribute describing their load herritage. 
+An example of how this can be used is the `make_location_trees`-function, which builds a tree-representation of the load process::
+
+    location_trees = make_location_trees(iter(bundle))
+    print('\n'.join(str(n) for n in location_trees))
+"""
+
 from abc import abstractmethod, abstractstaticmethod
 import logging, time
 from dataclasses import dataclass, field

--- a/pdtable/io/parsers/blocks.py
+++ b/pdtable/io/parsers/blocks.py
@@ -24,26 +24,26 @@ For each of these:
   - The original, raw cell grid, in case the user wants to do some low-level processing.
 
 """
+from abc import abstractmethod
 import itertools
 import re
-from typing import Sequence, Optional, Tuple, Any, Iterable, List, Union
-
+from typing import Sequence, Optional, Tuple, Any, Iterable, List, Union, Dict
+from collections import defaultdict
 import pandas as pd
+import warnings
 
 from pdtable import BlockType, BlockIterator
 from pdtable import Table
 from pdtable.io._json import to_json_serializable, JsonData, JsonDataPrecursor
-from pdtable.table_origin import LocationSheet, NullLocationFile, TableOrigin
+from pdtable.table_origin import LocationSheet, NullLocationFile, TableOrigin, InputIssue, InputIssueTracker, NullInputIssueTracker
 from .columns import parse_column
 from .fixer import ParseFixer
 from ... import frame
 from ...auxiliary import MetadataBlock, Directive
-from ...table_metadata import TableOriginCSV, TableMetadata
+from ...table_metadata import TableMetadata
 
 # Typing alias: 2D grid of cells with rows and cols. Intended indexing: cell_grid[row][col]
 CellGrid = Sequence[Sequence]
-
-VALID_PARSING_OUTPUT_TYPES = {"pdtable", "jsondata", "cellgrid"}
 
 
 def make_metadata_block(cells: CellGrid, origin: Optional[str] = None, **_) -> MetadataBlock:
@@ -62,7 +62,7 @@ def make_directive(cells: CellGrid, origin: Optional[str] = None, **_) -> Direct
     return Directive(name, directive_lines, origin)
 
 
-def default_fixer(origin, fixer=None, **kwargs):
+def make_fixer(origin, fixer=None, **kwargs):
     """ Determine if user has supplied custom fixer
         Else return default ParseFixer() instance.
     """
@@ -74,6 +74,7 @@ def default_fixer(origin, fixer=None, **kwargs):
         fixer = ParseFixer()
     assert fixer is not None
     fixer.origin = origin
+    fixer.reset_fixes()
     return fixer
 
 
@@ -88,7 +89,7 @@ def parse_column_names(column_names_raw: Sequence[Union[str, None]]) -> List[str
     ]
 
 
-def make_table_json_precursor(cells: CellGrid, **kwargs) -> Tuple[JsonDataPrecursor, bool]:
+def make_table_json_precursor(cells: CellGrid, fixer, origin) -> Tuple[JsonDataPrecursor, bool]:
     """Parses cell grid into a JSON-like data structure but with some non-JSON-native values
 
     Parses cell grid to a JSON-like data structure of nested "objects" (dict), "arrays" (list),
@@ -107,9 +108,6 @@ def make_table_json_precursor(cells: CellGrid, **kwargs) -> Tuple[JsonDataPrecur
     if transposed:
         # Chop off the transpose decorator from the name
         table_name = table_name[:-1]
-
-    fixer = default_fixer(**kwargs)
-    fixer.table_name = table_name
 
     # internally hold destinations as json-compatible dict
     destinations = {dest: None for dest in cells[1][0].strip().split(" ")}
@@ -168,7 +166,7 @@ def make_table_json_precursor(cells: CellGrid, **kwargs) -> Tuple[JsonDataPrecur
             data_rows[i_row] = fix_row
 
     # build dictionary of columns iteratively to allow meaningful error messages
-    columns = dict(zip(column_names, [[]]*len(column_names)))
+    columns = dict(zip(column_names, [[]] * len(column_names)))
     for name, unit, values in zip(column_names, units, zip(*data_rows)):
         try:
             fixer.column_name = name
@@ -180,18 +178,23 @@ def make_table_json_precursor(cells: CellGrid, **kwargs) -> Tuple[JsonDataPrecur
 
     fixer.report()
 
-    return {
-        "name": table_name,
-        "columns": columns,
-        "units": units,
-        "destinations": destinations,
-        "origin": kwargs.get("origin"),
-    }, transposed
+    return (
+        {
+            "name": table_name,
+            "columns": columns,
+            "units": units,
+            "destinations": destinations,
+            "origin": origin,
+        },
+        transposed,
+    )
 
 
-def make_table(cells: CellGrid, origin: Optional[TableOriginCSV] = None, **kwargs) -> Table:
+def make_table(cells: CellGrid, origin: TableOrigin, **kwargs) -> Table:
     """Parses cell grid into a pdtable-style Table block object."""
-    json_precursor, transposed = make_table_json_precursor(cells, origin=origin, **kwargs)
+    json_precursor, transposed = make_table_json_precursor(
+        cells, origin=str(origin.input_location), **kwargs
+    )
     return Table(
         frame.make_table_dataframe(
             pd.DataFrame(json_precursor["columns"]),
@@ -199,7 +202,7 @@ def make_table(cells: CellGrid, origin: Optional[TableOriginCSV] = None, **kwarg
             table_metadata=TableMetadata(
                 name=json_precursor["name"],
                 destinations=set(json_precursor["destinations"].keys()),
-                origin=json_precursor["origin"],
+                origin=origin,
                 transposed=transposed,
             ),
         )
@@ -220,35 +223,23 @@ def make_table_json_data(cells: CellGrid, origin, **kwargs) -> JsonData:
     return to_json_serializable(impure_json)
 
 
-def make_block(
-    block_type: BlockType, cells: CellGrid, origin, **kwargs
-) -> Tuple[Optional[BlockType], Optional[Any]]:
-    """Dispatches cell grid to the proper parser, depending on block type and desired output type"""
-    block_name = ""
-    if block_type == BlockType.METADATA:
-        factory = make_metadata_block
-    elif block_type == BlockType.DIRECTIVE:
-        factory = make_directive
-    elif block_type == BlockType.TABLE:
-        block_name = cells[0][0][2:]
-        to = kwargs.get("to")
-        if to == "cellgrid":
-            factory = lambda c, *_, **__: c  # Regurgitate the unprocessed cell grid  # noqa:E731
-        elif to == "jsondata":
-            factory = make_table_json_data
-        else:
-            factory = make_table
-    else:
-        factory = None
+def make_table_cell_grid(cells: CellGrid, origin, **kwargs) -> CellGrid:
+    return cells
 
-    block_filter = kwargs.get("filter")
-    if block_filter:
-        assert callable(block_filter)
-        if not block_filter(block_type, block_name):
-            return None, None
 
-    return block_type, cells if factory is None else factory(cells, origin, **kwargs)
+DEFAULT_HANDLERS = (
+    (BlockType.METADATA, make_metadata_block),
+    (BlockType.DIRECTIVE, make_directive),
+    (BlockType.TABLE, make_table),
+)
+_default_handlers = dict(DEFAULT_HANDLERS)
 
+TABLE_HANDLERS = (
+    ("pdtable", make_table),
+    ("jsondata", make_table_json_data),
+    ("cellgrid", make_table_cell_grid),
+)
+_table_handlers = dict(TABLE_HANDLERS)
 
 # Regex that matches valid block start markers
 _re_block_marker = re.compile(
@@ -266,54 +257,132 @@ _re_block_marker = re.compile(
 # $4 = Metadata:
 
 
+def _apply_filter(block_type, filter, handler):
+    if not block_type == BlockType.TABLE:
+        lambda cellgrid, *args, **kwargs: handler(cellgrid, *args, **kwargs) if filter(
+            block_type, ""
+        ) else None
+    return (
+        lambda cellgrid, *args, **kwargs: handler(cellgrid, *args, **kwargs)
+        if filter(block_type, cellgrid[0][0][2:])
+        else None
+    )
+
+
 def parse_blocks(
-    cell_rows: Iterable[Sequence], 
-    origin: LocationSheet = None, 
-    to: str = "pdtable", 
-    **kwargs) -> BlockIterator:
+    cell_rows: Iterable[Sequence],
+    location_sheet: LocationSheet = None,
+    to: str = "pdtable",
+    filter: Any = None,
+    **kwargs,
+) -> BlockIterator:
     """Parses blocks from a single sheet as rows of cells.
 
     Takes an iterable of cell rows and parses it into blocks.
 
     Args:
-        cell_rows: Iterable of cell rows, where each row is a sequence of cells.
+        cell_rows: 
+            Iterable of cell rows, where each row is a sequence of cells.
+        location_sheet: 
+            A `LocationSheet` object describing the sheet being read.
+        filter: 
+            Optional. Will be called as (block type, name | ""). Block is dropped if false.
+        to: 
+            Optional. Generate Table of this type ("pdtable", "jsondata", "cellgrid")
     kwargs:
-        origin: A thing.
         fixer: Also a thing, but different.
-        to: generate Table of this type ("pdtable", "jsondata", "cellgrid")
-
     Yields:
         Blocks.
     """
 
-    # Unpack, pre-process, validate, and repack the kwargs for downstream use
-    if to not in VALID_PARSING_OUTPUT_TYPES:
+    # Set up handlers
+    # Legacy default is to emit unknown types as raw cells, so use defaultdict
+    handlers = defaultdict(lambda: make_table_cell_grid, DEFAULT_HANDLERS)
+    try:
+        handlers[BlockType.TABLE] = _table_handlers[to]
+    except KeyError:
         raise ValueError(
-            f"Unknown parsing output type; expected one of {VALID_PARSING_OUTPUT_TYPES}.", to
+            f"Unknown parsing output type; expected one of {list(_table_handlers.keys())}.", to
         )
+    if filter:
+        for k, base_handler in handlers.items():
+            handlers[k] = _apply_filter(k, filter, base_handler)
 
-    if origin is None:
-        origin = LocationSheet(file=NullLocationFile(), sheet_name=None)
+    if kwargs:
+        origin_str = location_sheet.file.load_identifier if location_sheet is not None else ""
+        fixer = make_fixer(origin=origin_str, **kwargs)
+    else:
+        fixer = None
 
-    # TODO: inject fixer
-    fixer = default_fixer(origin=origin.file.load_identifier, **kwargs)
-    fixer.reset_fixes()
+    yield from parse_blocks_stable(
+        cell_rows, location_sheet=location_sheet, block_handlers=handlers, fixer=fixer
+    )
 
-    def block_output(state, row: int, cell_grid):
-        if not cell_grid:
+
+# Regex that matches valid block start markers
+_re_block_marker = re.compile(
+    r"^("  # Marker must start exactly at start of cell
+    r"(?<!\*)(\*\*\*?)(?!\*)"  # **table or ***directive but not ****undefined
+    r"|"
+    r"((?<!:):{1,3}(?!:))[^:]*\s*$"  # :col, ::table, :::file but not ::::undefined, :ambiguous:
+    r"|"
+    r"([^:]+:)\s*$"  # metadata:  but not :ambiguous:
+    r")"
+)
+# $1 = Valid block start marker
+# $2 = **Table / ***Directive
+# $3 = :Template
+# $4 = Metadata:
+
+def parse_blocks_stable(
+    cell_rows: Iterable[Sequence],
+    issue_tracker: InputIssueTracker = None,
+    block_handlers: Dict[BlockType, Any] = None,
+    location_sheet: LocationSheet = None,
+    fixer: Any = None,
+) -> BlockIterator:
+
+    if location_sheet is None:
+        location_sheet = LocationSheet(file=NullLocationFile(), sheet_name=None)
+
+    if issue_tracker is None:
+        issue_tracker = NullInputIssueTracker()
+
+    if block_handlers is None:
+        block_handlers = dict(DEFAULT_HANDLERS)
+
+    if fixer is None:
+        fixer = make_fixer(origin=location_sheet.file.load_identifier)
+    else:
+        warnings.warn(
+            "The fixer construct is deprecated and will be removed in future release."
+            "Please file an issue describing fixer use case at https://github.com/startable/pdtable/issues.",
+            DeprecationWarning, stacklevel=2)
+
+    def block_output(block_type, cell_grid, row: int):
+        """
+        Emit cell_grid as given block_type
+        """
+        if not cell_grid:  # return on None or empty
             return
-        location = TableOrigin(input_location=origin.make_location_block(row=row))
-        block_type, block = make_block(state, cell_grid, origin=location, to=to, fixer=fixer)
-        if block_type is not None:
+        handler = block_handlers.get(block_type, None)
+        if handler is None:
+            return
+        origin = TableOrigin(input_location=location_sheet.make_location_block(row=row))
+
+        try:
+            block = handler(cell_grid, origin=origin, fixer=fixer)
+        except ValueError as e:
+            issue_tracker.add_error(e, origin=origin)
+
+        if block is not None:
             yield block_type, block
 
     cell_grid = []
-
     state = BlockType.METADATA
     next_state = None
     this_block_1st_row = 0
     for row_number_0based, row in enumerate(cell_rows):
-        #  print(f"parse_blocks: {state} {row[0] if len(row) > 0 else ' (empty) '}")
         if row is None or len(row) == 0 or _is_cell_blank(row[0]):
             if state != BlockType.BLANK:
                 next_state = BlockType.BLANK
@@ -346,7 +415,7 @@ def parse_blocks(
 
         if next_state is not None:
             # Current block has ended. Emit it.
-            yield from block_output(state, this_block_1st_row, cell_grid)
+            yield from block_output(state, cell_grid, this_block_1st_row)
             cell_grid = []
             state = next_state
             next_state = None
@@ -359,7 +428,7 @@ def parse_blocks(
                     continue
                 cell_grid.append(row)
 
-    yield from block_output(state, this_block_1st_row, cell_grid)
+    yield from block_output(state, cell_grid, this_block_1st_row)
 
 
 def _fix_duplicate_column_names(col_names_raw: Sequence[str], fixer: ParseFixer):

--- a/pdtable/table_metadata.py
+++ b/pdtable/table_metadata.py
@@ -34,10 +34,8 @@ class TableMetadata:
         )
         src = ""
         if self.origin:
-            src = f" from {self.origin}"
-        if self.parents:
-            src = " from {{{}}}".format(",".join(f"\n{c}" for c in self.parents))
-        return f'Table "{self.name}" {dst}. {self.operation}{src}'
+            src = f" From {self.origin}"
+        return f'Table "{self.name}" {dst}.{src}'
 
 
 class ColumnFormat:

--- a/pdtable/table_metadata.py
+++ b/pdtable/table_metadata.py
@@ -4,33 +4,10 @@ from typing import Set, List, Optional, Dict, Union
 import numpy
 import pandas as pd
 
+from .table_origin import TableOrigin
 
 class InvalidNamingError(Exception):
     pass
-
-
-class TableOrigin:
-    """
-    A TableOrigin instance uniquely defines the source of a Table instance.
-
-    Subclasses should take care to define __str__.
-    If possible, as_html() should be defined to include backlink to original input.
-    """
-
-    def as_html(self) -> str:
-        return str(self)
-
-
-class TableOriginCSV(TableOrigin):
-    def __init__(self, file_name: str = "", row: int = 0):
-        self._file_name = file_name
-        self._row = row
-
-    def __str__(self) -> str:
-        return f'"{self._file_name}" row {self._row}'
-
-    def __repr__(self) -> str:
-        return f"TableOriginCSV({self})"
 
 
 @dataclass
@@ -46,11 +23,7 @@ class TableMetadata:
 
     name: str
     destinations: Set[str] = field(default_factory=lambda: {"all"})
-    operation: str = "Created"
-    parents: List["TableMetadata"] = field(default_factory=list)
-    origin: Optional[
-        str
-    ] = ""  # Should be replaced with a TableOrigin object to allow file-edit access
+    origin: Optional[TableOrigin] = None
     transposed: bool = False
 
     def __str__(self):

--- a/pdtable/table_origin.py
+++ b/pdtable/table_origin.py
@@ -1,10 +1,23 @@
 from pdtable.store import BlockIterator, BlockType
-from typing import Protocol, Iterator, Any, NamedTuple, Iterable, Optional, Set, Tuple, Callable
-from abc import abstractmethod, abstractstaticmethod
+from typing import (
+    Protocol,
+    Iterator,
+    Any,
+    NamedTuple,
+    Iterable,
+    Optional,
+    Set,
+    Tuple,
+    Callable,
+    List,
+    Dict,
+)
+from abc import abstractmethod, abstractproperty, abstractstaticmethod
 import logging, time
 from dataclasses import dataclass, field
 from pathlib import Path, PosixPath
-import sys, os, subprocess
+import sys, os, subprocess, datetime, html, random, base64
+
 
 class LoadLocation(Protocol):
     @property
@@ -17,7 +30,7 @@ class LoadLocation(Protocol):
 
     @property
     @abstractmethod
-    def load_specification(self) -> LoadItem:
+    def load_specification(self) -> "LoadItem":
         pass
 
     @property
@@ -25,20 +38,18 @@ class LoadLocation(Protocol):
     def load_identifier(self) -> str:
         pass
 
-
     @abstractmethod
-    def open_interactive(self, read_only: bool = False):
+    def interactive_open(self, read_only: bool = False):
         pass
 
 
 class LoadItem(NamedTuple):
     specification: str
-    source: LoadLocation
+    source: Optional[LoadLocation]
 
     @property
-    @abstractmethod
     def source_identifier(self) -> str:
-        return self.source.load_identifier
+        return "<root>" if self.source is None else self.source.load_identifier
 
     def load_history(self) -> Iterator["LoadItem"]:
         """
@@ -51,10 +62,11 @@ class LoadItem(NamedTuple):
 
         Example text representation
         ```
-        included as "doreco:input_foo_DOR12345" from "/mpmp/input_include.csv@2021-01-02T1233" row 27
-        included as "input_include.csv" from "/mpmp"
-        included as "mpmp/" from "/input_all.csv@123123123" row 12
+        included as "doreco:input_foo_DOR12345" from "/mp/input_include.csv@2021-01-02T1233" row 27
+        included as "input_include.csv" from "/mp"
+        included as "mp/" from "/input_all.csv@123123123" row 12
         included as "input_all.csv" from "/"
+        included as "/" from "<root>"
         ```
         """
         yield self
@@ -62,7 +74,21 @@ class LoadItem(NamedTuple):
             yield from self.source.load_specification.load_history()
 
     def __str__(self) -> str:
-        return ';'.join(f'included as "{li.specification} from "{li.source_identifier}"' for li in self.load_history())
+        return ";".join(
+            f'included as "{li.specification} from "{li.source_identifier}"'
+            for li in self.load_history()
+        )
+
+
+def interactive_open_uri(uri):
+    """
+    A cross-platform functionality for launching tool by URI
+    """
+    if sys.platform == "win32":
+        os.startfile(uri)
+    else:
+        opener = "open" if sys.platform == "darwin" else "xdg-open"
+        subprocess.call([opener, uri])
 
 
 class LocationFile(Protocol):
@@ -87,7 +113,7 @@ class LocationFile(Protocol):
 
     @property
     @abstractmethod
-    def file_identifier(self) -> str:
+    def load_identifier(self) -> str:
         """
         Unique identifier of loaded item
         
@@ -96,68 +122,234 @@ class LocationFile(Protocol):
         """
         pass
 
-    # TODO: Should this field just be left out?
-    @property
-    @abstractmethod
-    def file_metadata(self) -> Any:
-        """
-        For use by loader framework
-        """
-        pass
-
     @property
     @abstractmethod
     def local_path(self) -> Optional[Path]:
         pass
 
-    @abstractmethod
-    def open_interactive(self, sheet: Optional[str]=None, row: Optional[int]=None, read_only=True):
-        pass
+    @property
+    def local_folder_path(self) -> Optional[Path]:
+        return None if self.local_path is None else self.local_path.parent
 
     @abstractmethod
+    def interactive_uri(
+        self, sheet: Optional[str] = None, row: Optional[int] = None, read_only=True
+    ) -> Optional[str]:
+        pass
+
+    def interactive_open(
+        self, sheet: Optional[str] = None, row: Optional[int] = None, read_only=True
+    ):
+        uri = self.interactive_uri(sheet, row, read_only)
+        interactive_open_uri(uri)
+
+    def get_interactive_identifier(
+        self, sheet: Optional[str] = None, row: Optional[int] = None
+    ) -> str:
+        """
+        Defaults to load identifier, but may be replaced with replacement better suited for interactive use
+        """
+        s_loc = "" if sheet is None else f" Sheet '{sheet}'"
+        r_loc = "" if row is None else f" Row {row}"
+
+        return self.load_identifier + s_loc + r_loc
+
+    @property
+    def interactive_identifier(self) -> str:
+        return self.get_interactive_identifier()
+
     def get_local_path(self) -> Path:
         """
         Always return path to local instance
 
         Will write contents to local storage if not available.
         """
-        pass
+        if self.local_path is not None:
+            return self.local_path
+        raise NotImplementedError("Automatic download not implemented")
 
+    def make_location_sheet(self, sheet_name: Optional[str] = None):
+        return LocationSheet(file=self, sheet_name=sheet_name)
+
+
+def _random_id() -> str:
+    return base64.b32encode(os.urandom(5*2)).decode('ascii')
+
+@dataclass(frozen=True)
+class NullLocationFile:
+    """
+    Null-implementation of LocationFile
+    """
+    load_specification: LoadItem = field(default_factory = lambda: LoadItem("Unknown", source=None))
+    load_identifier: str = field(default_factory = lambda: f"<Random load identifier - {_random_id()}>")
+    local_path: Optional[Path] = None
+
+    def interactive_uri(
+        self, sheet: Optional[str] = None, row: Optional[int] = None, read_only=True
+    ) -> Optional[str]:
+        return None
+        
 
 class LocationFolder(NamedTuple):
     local_folder_path: Path
+    load_specification: LoadItem
 
     @property
     def load_identifier(self) -> str:
-        return self.local_folder_path
-        
-    def open_interactive(self):
-        if sys.platform == "win32":
-            os.startfile(self.local_folder_path)
-        else:
-            opener = "open" if sys.platform == "darwin" else "xdg-open"
-            subprocess.call([opener, self.local_folder_path])
+        return str(self.local_folder_path)
+
+    @property
+    def interactive_identifier(self) -> str:
+        return self.load_identifier
+
+    def interactive_uri(self, read_only=False) -> str:
+        return self.local_folder_path.as_uri()
+
+    def interactive_open(self):
+        interactive_open_uri(self.interactive_uri())
+
+    @classmethod
+    def make_location_folder(
+        cls, local_folder_path: Path, load_specification: LoadItem = None
+    ) -> "LocationFolder":
+        if load_specification is None:
+            load_specification = LoadItem(str(local_folder_path), source=None)
+        return cls(local_folder_path=local_folder_path, load_specification=load_specification)
 
 
 @dataclass(frozen=True)  # to allow empty dict default
 class LocationSheet:
     file: LocationFile
-    sheet_name: Optional[str] 
+    sheet_name: Optional[str]
     sheet_metadata: Dict[str, str] = field(default_factory=dict)
 
+    def make_location_block(self, row: int):
+        return LocationBlock(sheet=self, row=row)
 
 class LocationBlock(NamedTuple):
     sheet: LocationSheet
     row: int
 
     @property
+    def file(self) -> LocationFile:
+        return self.sheet.file
+
+    @property
     def sheet_name(self) -> Optional[str]:
         return self.sheet.sheet_name
 
     @property
-    def local_folder_path(self) -> Path:
+    def local_folder_path(self) -> Optional[Path]:
         return self.file.local_folder_path
 
     @property
     def load_identifier(self) -> str:
-        return self.file.load_identifier()
+        return self.file.load_identifier
+
+    @property
+    def interactive_identifier(self) -> str:
+        return self.file.get_interactive_identifier(sheet=self.sheet_name, row=self.row)
+
+    def interactive_uri(self, read_only: bool = False):
+        return self.file.interactive_uri(sheet=self.sheet_name, row=self.row, read_only=read_only)
+
+    def interactive_open(self, read_only: bool = False):
+        interactive_open_uri(self.interactive_uri(read_only=read_only))
+
+
+@dataclass(frozen=True)
+class TableOrigin:
+    """
+    A TableOrigin instance defines the source of a Table instance.
+
+    The source may either be a loaded input table or an operation combining multiple
+    parents (represented by TableOrigin instances) into a derived table, so that each
+    ``TableOrigin``-instance is the root of a tree of ``TableOrigin`` instances.
+
+    Each node in the tree is either a _leaf_, corresponding to a loaded input, in which 
+    case only ``input_location`` is defined, or a _branch_, corresponding to a derived
+    table, in which case only ``parents`` and ``operation`` are defined.
+    
+    For an integrated representation of this information, an application should traverse
+    the tree and provide a representation in the most convenient form. For an example, 
+    see ``table_origin_as_html`` or ``table_origin_as_str``.
+    """
+
+    input_location: Optional[LocationBlock] = None
+    parents: Iterable["TableOrigin"] = ()
+    operation: Optional[str] = None
+
+    def _post_init_(self):
+        if self.operation is None:
+            # leaf
+            if self.parents or self.input_location is None:
+                raise ValueError("For TableOrigin leaf node, only input_location must be defined")
+        else:
+            # branch
+            if self.input_location is not None or not self.parents:
+                raise ValueError(
+                    "For TableOrigin branch node, only operation and parents should be defined"
+                )
+
+    @property
+    def is_leaf(self):
+        return self.operation is None
+
+    def get_input_ancestors(self) -> Iterator[LocationBlock]:
+        """
+        Return iterator over the input-location of all non-derived ancestors
+        """
+        if self.is_leaf:
+            if self.input_location:
+                yield self.input_location
+            else:
+                raise ValueError("Inconsistent state of TableOrigin")
+        else:
+            for p in self.parents:
+                yield from p.get_input_ancestors()
+
+    def __str__(self):
+        return table_origin_as_str(self)
+
+    def _repr_html_(self) -> str:
+        return table_origin_as_html(self)
+
+
+def table_origin_as_html(tt: TableOrigin):
+    def visit(tt):
+        return visit_branch(tt) if tt.input_location is None else visit_leaf(tt)
+
+    def visit_leaf(tt):
+        loc = tt.input_location
+        return (
+            f"""<a href="{loc.interactive_uri()}" class="input-table-origin">"""
+            f"""{html.escape(loc.interactive_identifier)}</a>"""
+        )
+
+    def visit_branch(tt):
+        return (
+            f"""<div class="derived-table-origin"><span>{html.escape(tt.operation)}</span><ul>"""
+            + "\n".join(f"<li>{visit(p)}</li>" for p in tt.parents)
+            + """</ul></div>"""
+        )
+
+    return visit(tt)
+
+
+def table_origin_as_str(tt: TableOrigin):
+    buf: List[Tuple[int, str]] = []
+
+    def visit(tt, lev):
+        return visit_branch(tt, lev) if tt.input_location is None else visit_leaf(tt, lev)
+
+    def visit_leaf(tt, lev):
+        buf.append((lev, tt.input_location.interactive_identifier))
+
+    def visit_branch(tt, lev):
+        buf.append((lev, f"Derived via {tt.operation} from:"))
+        for p in tt.parents:
+            visit(p, lev + 1)
+
+    visit(tt, 0)
+    return "\n".join("  " * lev + s for lev, s in buf)
+

--- a/pdtable/table_origin.py
+++ b/pdtable/table_origin.py
@@ -1,0 +1,163 @@
+from pdtable.store import BlockIterator, BlockType
+from typing import Protocol, Iterator, Any, NamedTuple, Iterable, Optional, Set, Tuple, Callable
+from abc import abstractmethod, abstractstaticmethod
+import logging, time
+from dataclasses import dataclass, field
+from pathlib import Path, PosixPath
+import sys, os, subprocess
+
+class LoadLocation(Protocol):
+    @property
+    @abstractmethod
+    def local_folder_path(self) -> Optional[Path]:
+        """
+        Used for resolving relative imports
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def load_specification(self) -> LoadItem:
+        pass
+
+    @property
+    @abstractmethod
+    def load_identifier(self) -> str:
+        pass
+
+
+    @abstractmethod
+    def open_interactive(self, read_only: bool = False):
+        pass
+
+
+class LoadItem(NamedTuple):
+    specification: str
+    source: LoadLocation
+
+    @property
+    @abstractmethod
+    def source_identifier(self) -> str:
+        return self.source.load_identifier
+
+    def load_history(self) -> Iterator["LoadItem"]:
+        """
+        Return the load tree leading up to this load item
+
+        Typical use:
+        ```
+        '\n'.join(f'included as "{li.spec} from "{li.source_identifier}"' for li in load_specification.load_history())
+        ```
+
+        Example text representation
+        ```
+        included as "doreco:input_foo_DOR12345" from "/mpmp/input_include.csv@2021-01-02T1233" row 27
+        included as "input_include.csv" from "/mpmp"
+        included as "mpmp/" from "/input_all.csv@123123123" row 12
+        included as "input_all.csv" from "/"
+        ```
+        """
+        yield self
+        if self.source:
+            yield from self.source.load_specification.load_history()
+
+    def __str__(self) -> str:
+        return ';'.join(f'included as "{li.specification} from "{li.source_identifier}"' for li in self.load_history())
+
+
+class LocationFile(Protocol):
+    """
+    Represents a traceable load entity
+
+    The load entity could be a file, a blob, an http response. The LocationFile instance
+    should hold enough information to uniquely identify (and if possible allow recreation)
+    of the block stream resulting of loading this entity.
+    """
+
+    @property
+    @abstractmethod
+    def load_specification(self) -> LoadItem:
+        """
+        The specification passed to Loader instance as LoadItem to retrieve this file
+
+        The specification may not uniquely identify the file, as i may include partial
+        record specifications (e.g. "use latest") resolved at load time.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def file_identifier(self) -> str:
+        """
+        Unique identifier of loaded item
+        
+        Must be unique to allow import loop detection and input caching.
+        For local files, this could be absolute path and modification time.
+        """
+        pass
+
+    # TODO: Should this field just be left out?
+    @property
+    @abstractmethod
+    def file_metadata(self) -> Any:
+        """
+        For use by loader framework
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def local_path(self) -> Optional[Path]:
+        pass
+
+    @abstractmethod
+    def open_interactive(self, sheet: Optional[str]=None, row: Optional[int]=None, read_only=True):
+        pass
+
+    @abstractmethod
+    def get_local_path(self) -> Path:
+        """
+        Always return path to local instance
+
+        Will write contents to local storage if not available.
+        """
+        pass
+
+
+class LocationFolder(NamedTuple):
+    local_folder_path: Path
+
+    @property
+    def load_identifier(self) -> str:
+        return self.local_folder_path
+        
+    def open_interactive(self):
+        if sys.platform == "win32":
+            os.startfile(self.local_folder_path)
+        else:
+            opener = "open" if sys.platform == "darwin" else "xdg-open"
+            subprocess.call([opener, self.local_folder_path])
+
+
+@dataclass(frozen=True)  # to allow empty dict default
+class LocationSheet:
+    file: LocationFile
+    sheet_name: Optional[str] 
+    sheet_metadata: Dict[str, str] = field(default_factory=dict)
+
+
+class LocationBlock(NamedTuple):
+    sheet: LocationSheet
+    row: int
+
+    @property
+    def sheet_name(self) -> Optional[str]:
+        return self.sheet.sheet_name
+
+    @property
+    def local_folder_path(self) -> Path:
+        return self.file.local_folder_path
+
+    @property
+    def load_identifier(self) -> str:
+        return self.file.load_identifier()

--- a/pdtable/test/io/input/with_include/bar.csv
+++ b/pdtable/test/io/input/with_include/bar.csv
@@ -1,0 +1,5 @@
+**bar_table
+all
+col_1;col_2;
+-;-;
+1;1;

--- a/pdtable/test/io/input/with_include/bar_abs.csv
+++ b/pdtable/test/io/input/with_include/bar_abs.csv
@@ -1,0 +1,6 @@
+**bar_abs_table
+all
+col_1;col_2;
+-;-;
+1;1;
+

--- a/pdtable/test/io/input/with_include/input_foo.csv
+++ b/pdtable/test/io/input/with_include/input_foo.csv
@@ -1,0 +1,3 @@
+***include
+bar.csv
+/bar_abs.csv

--- a/pdtable/test/io/parsers/test_block_parsers.py
+++ b/pdtable/test/io/parsers/test_block_parsers.py
@@ -472,9 +472,9 @@ def test_parse_blocks__block_types():
     ]
     # fmt: on
 
+    parse_result = list(parse_blocks(cell_rows, to="cellgrid"))
     seen = {}
-    for ty, block in parse_blocks(cell_rows, to="cellgrid"):
-        #  print(f"\n-oOo- {ty} {block}")
+    for ty, block in parse_result:
         if seen.get(ty) is None:
             seen[ty] = []
         seen[ty].append(block)

--- a/pdtable/test/io/test_load.py
+++ b/pdtable/test/io/test_load.py
@@ -1,9 +1,11 @@
+
+from textwrap import dedent
 from pathlib import Path
 from pdtable.store import BlockType
 
 from pdtable import read_csv, Table
 from pdtable.table_origin import LoadItem, TableOrigin, LocationFile
-from pdtable.io.load import FilesystemLoader, load_files, LoadOrchestrator
+from pdtable.io.load import FilesystemLoader, load_files, LoadOrchestrator, make_location_trees
 
 def test_include():
     input_folder = Path(__file__).parent / 'input/with_include'
@@ -20,3 +22,15 @@ def test_include():
             """included as "/" from "<root>""",
         ]
     ))
+
+    location_trees = make_location_trees(res.values())
+    tree_as_str = '\n'.join(str(n) for n in location_trees)
+    reference_str = dedent(f"""
+    <root_folder: {input_folder}>
+      Row 0 of 'input_foo.csv'
+        bar_abs.csv
+          **bar_abs_table
+        bar.csv
+          **bar_table
+    """).strip()
+    assert tree_as_str == reference_str

--- a/pdtable/test/io/test_load.py
+++ b/pdtable/test/io/test_load.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from pdtable.store import BlockType
+
+from pdtable import read_csv, Table
+from pdtable.table_origin import LoadItem, TableOrigin, LocationFile
+from pdtable.io.load import FilesystemLoader, load_all, LoadOrchestrator
+
+def test_include():
+    input_folder = Path(__file__).parent / 'input/with_include'
+
+    def read(location_file: LocationFile, _: LoadOrchestrator):
+        # origin = TableOrigin(input_location=location_file.make_location_sheet().make_location_block(row=1))
+        origin = location_file.make_location_sheet()
+        yield from read_csv(location_file.get_local_path(), origin=origin)
+
+    roots = [LoadItem('/', source=None)]
+    loader=FilesystemLoader(file_reader=read, root_folder=input_folder)
+    res = [b for b in load_all(roots, loader)]
+
+    assert {b.name for t, b in res if t==BlockType.TABLE} == {'bar_table', 'bar_abs_table'}

--- a/pdtable/test/io/test_load.py
+++ b/pdtable/test/io/test_load.py
@@ -9,9 +9,8 @@ def test_include():
     input_folder = Path(__file__).parent / 'input/with_include'
 
     def read(location_file: LocationFile, _: LoadOrchestrator):
-        # origin = TableOrigin(input_location=location_file.make_location_sheet().make_location_block(row=1))
-        origin = location_file.make_location_sheet()
-        yield from read_csv(location_file.get_local_path(), origin=origin)
+        location_sheet = location_file.make_location_sheet()
+        yield from read_csv(location_file.get_local_path(), location_sheet=location_sheet)
 
     roots = [LoadItem('/', source=None)]
     loader=FilesystemLoader(file_reader=read, root_folder=input_folder)

--- a/pdtable/test/io/test_load.py
+++ b/pdtable/test/io/test_load.py
@@ -3,17 +3,20 @@ from pdtable.store import BlockType
 
 from pdtable import read_csv, Table
 from pdtable.table_origin import LoadItem, TableOrigin, LocationFile
-from pdtable.io.load import FilesystemLoader, load_all, LoadOrchestrator
+from pdtable.io.load import FilesystemLoader, load_files, LoadOrchestrator
 
 def test_include():
     input_folder = Path(__file__).parent / 'input/with_include'
+    res = {b.name: b for t, b in load_files(['/'], root_folder=input_folder, csv_sep=';') if t==BlockType.TABLE}
 
-    def read(location_file: LocationFile, _: LoadOrchestrator):
-        location_sheet = location_file.make_location_sheet()
-        yield from read_csv(location_file.get_local_path(), location_sheet=location_sheet)
+    assert set(res.keys()) == {'bar_table', 'bar_abs_table'}
+    input_location = res['bar_table'].metadata.origin.input_location
 
-    roots = [LoadItem('/', source=None)]
-    loader=FilesystemLoader(file_reader=read, root_folder=input_folder)
-    res = [b for b in load_all(roots, loader)]
-
-    assert {b.name for t, b in res if t==BlockType.TABLE} == {'bar_table', 'bar_abs_table'}
+    assert all(s.startswith(ref) for s, ref in zip(
+        str(input_location.file.load_specification).split(';'),
+        [
+            """included as "bar.csv" from """,
+            """included as "input_foo.csv" from """,
+            """included as "/" from "<root>""",
+        ]
+    ))

--- a/pdtable/test/io/test_load.py
+++ b/pdtable/test/io/test_load.py
@@ -1,15 +1,22 @@
-
+import pytest
 from textwrap import dedent
 from pathlib import Path
-from pdtable.store import BlockType
+import re
 
+from pdtable.store import BlockType
 from pdtable import read_csv, Table
 from pdtable.table_origin import LoadItem, TableOrigin, LocationFile
 from pdtable.io.load import FilesystemLoader, load_files, LoadOrchestrator, make_location_trees
 
-def test_include():
-    input_folder = Path(__file__).parent / 'input/with_include'
-    res = {b.name: b for t, b in load_files(['/'], root_folder=input_folder, csv_sep=';') if t==BlockType.TABLE}
+
+@pytest.fixture
+def input_folder():
+    return Path(__file__).parent / 'input'
+
+
+def test_include(input_folder):
+    root_folder = input_folder /'with_include'
+    res = {b.name: b for t, b in load_files(['/'], root_folder=root_folder, csv_sep=';') if t==BlockType.TABLE}
 
     assert set(res.keys()) == {'bar_table', 'bar_abs_table'}
     input_location = res['bar_table'].metadata.origin.input_location
@@ -26,7 +33,7 @@ def test_include():
     location_trees = make_location_trees(res.values())
     tree_as_str = '\n'.join(str(n) for n in location_trees)
     reference_str = dedent(f"""
-    <root_folder: {input_folder}>
+    <root_folder: {root_folder}>
       Row 0 of 'input_foo.csv'
         bar_abs.csv
           **bar_abs_table
@@ -34,3 +41,12 @@ def test_include():
           **bar_table
     """).strip()
     assert tree_as_str == reference_str
+
+
+def test_excel(input_folder):
+    blocks = load_files(['/'], root_folder=input_folder, 
+                        file_name_pattern=re.compile(r'.*\.xlsx$'),
+                        sheet_name_pattern=re.compile(r'.*'))
+    res = [b for t, b in blocks  if t==BlockType.TABLE]
+
+    assert len(res) == 6

--- a/pdtable/test/io/test_read_csv_json.py
+++ b/pdtable/test/io/test_read_csv_json.py
@@ -49,7 +49,7 @@ def test_json_pdtable():
     ]
     pandas_pdtab = None
     # with io.StringIO(csv_src) as fh:
-    g = parse_blocks(cell_rows, **{"origin": '"types1.csv" row 1'}, fixer=custom_test_fixer)
+    g = parse_blocks(cell_rows, **{"origin": '"types1.csv" row 1'}, fixer=custom_test_fixer())
     for tp, tab in g:
         pandas_pdtab = tab
     # fmt: off
@@ -69,7 +69,7 @@ def test_json_pdtable():
     }
     # fmt: on
 
-    json_pdtab = json_data_to_table(table_json_data, fixer=custom_test_fixer)
+    json_pdtab = json_data_to_table(table_json_data, fixer=custom_test_fixer())
     assert pandas_pdtab.equals(json_pdtab)
 
 
@@ -91,7 +91,7 @@ def test_json_data_to_pdtable():
         ["goose", 2, 9, 0],
     ]
 
-    table_from_cell_grid = make_table(lines_target, fixer=custom_test_fixer)
+    table_from_cell_grid = make_table(lines_target, fixer=custom_test_fixer())
 
     # Make an identical table, but starting from JSON
 
@@ -112,12 +112,12 @@ def test_json_data_to_pdtable():
     }
     # fmt: on
 
-    table_from_json = json_data_to_table(table_json_data, fixer=custom_test_fixer)
+    table_from_json = json_data_to_table(table_json_data, fixer=custom_test_fixer())
     assert table_from_cell_grid.equals(table_from_json)
 
     # Round trip
     table_json_data_back = table_to_json_data(table_from_json)
-    table_from_json_round_trip = json_data_to_table(table_json_data_back, fixer=custom_test_fixer)
+    table_from_json_round_trip = json_data_to_table(table_json_data_back, fixer=custom_test_fixer())
     assert table_from_cell_grid.equals(table_from_json_round_trip)
 
 
@@ -150,7 +150,7 @@ def test_fat():
         with open(input_dir() / fn, "r") as fh:
             cell_rows = (line.rstrip("\n").split(";") for line in fh)
             g = parse_blocks(
-                cell_rows, **{"origin": f'"{fn}"', "to": "jsondata"}, fixer=custom_test_fixer
+                cell_rows, **{"origin": f'"{fn}"', "to": "jsondata"}, fixer=custom_test_fixer()
             )
 
             for tp, tt in g:
@@ -236,7 +236,7 @@ def test_make_table_json_data__empty_table():
         ["text", "-", "kg", "onoff"]
     ]
     # parse the table to a jsondata
-    table_json_data = make_table_json_data(lines_target, 'farm_types1.csv', fixer=custom_test_fixer)
+    table_json_data = make_table_json_data(lines_target, 'farm_types1.csv', fixer=custom_test_fixer())
 
     exp_table_json_data = {
       "name": "farm_types1",
@@ -256,6 +256,6 @@ def test_make_table_json_data__empty_table():
     assert table_json_data == exp_table_json_data
 
     # and json with empty values can be created into table
-    table_from_json = json_data_to_table(table_json_data, fixer=custom_test_fixer)
+    table_from_json = json_data_to_table(table_json_data, fixer=custom_test_fixer())
     table_from_lines = make_table(lines_target, fixer=custom_test_fixer)
     assert table_from_lines.equals(table_from_json)


### PR DESCRIPTION
I am out of timebox on this one, but it seems to be at a reasonable place: Should not break anything, and the core data structures and functionality is in place. Compared to our discussion, I let the fixer stay but added a depreciation warning.
The only intentional functional change is that the input errors are now reported as `InputError` rather than `ValueError`, but I don't know if we should bump the version number enough to let people postpone the upgrade if they need to.

One functional question: I set the default loader `file_name_pattern` and `sheet_name_pattern` to match those of optiMon (i.e. `^(input|setup)_`. Maybe we should go for something less opinionated?