### PR TITLE
Fix deprecation warning by changing dtype from np.str to str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet. 
+### Fixed
+- In response to a Numpy deprecation warning, changed one `dtype` argument from deprecated `numpy.str` to its designated successor, built-in `str`.
 
 ## [0.0.10] - 2021-03-16
 

--- a/pdtable/io/parsers/columns.py
+++ b/pdtable/io/parsers/columns.py
@@ -35,7 +35,7 @@ def is_missing_data_marker(normalized_val):
 
 def _parse_text_column(values: Iterable, fixer: ParseFixer = None):
     # Ensure that 'values' is a Sequence, else np.array() will not unpack it
-    return np.array(values if isinstance(values, Sequence) else list(values), dtype=np.str)
+    return np.array(values if isinstance(values, Sequence) else list(values), dtype=str)
 
 
 def _onoff_to_bool(val) -> bool:


### PR DESCRIPTION
In response to a deprecation warning, changed one `dtype` from the deprecated `numpy.str` to its designated successor, the built-in `str`.

```
  C:\Users\jeaco\Anaconda3\envs\sutokura\lib\site-packages\pdtable\io\parsers\columns.py:38: DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return np.array(values if isinstance(values, Sequence) else list(values), dtype=np.str)
```