### PR TITLE
Fix bug to excel writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16]
+
+### Fixed
+- Bug causing `write_excel` `engine_kwargs` arguments to not be passed on to the engine.
+
 ## [0.0.15]
 
 ### Added

--- a/pdtable/__init__.py
+++ b/pdtable/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 
 CSV_SEP = ";"  # User can overwrite this default
 

--- a/pdtable/io/excel.py
+++ b/pdtable/io/excel.py
@@ -208,5 +208,5 @@ def write_excel(
             f"Tried using: '{backend.name.lower()}'.\n"
             f"Please install {backend.name.lower()} for Excel I/O support."
         ) from err
-    engine_kwargs = {} if engine_kwargs is None else {}
+    engine_kwargs = {} if engine_kwargs is None else engine_kwargs
     write_excel_func(tables, to, na_rep, styles, sep_lines, engine_kwargs)


### PR DESCRIPTION
 `engine _kwargs` were not passed on to the engine