### PR TITLE
TableDataFrame finalization warnings fixes

### DIFF
--- a/pdtable/frame.py
+++ b/pdtable/frame.py
@@ -82,7 +82,8 @@ def _combine_tables(
 
     if method is None or method in frozenset({
             "reindex", "take", "copy", "groupby", "replace", "sort_index",
-            "transpose", "astype", "append", "fillna", "rename"
+            "transpose", "astype", "append", "fillna", "rename", "unstack",
+            "melt"
     }):
         # method: None - copy, slicing (pandas <1.1)
         src = [other]

--- a/pdtable/frame.py
+++ b/pdtable/frame.py
@@ -80,7 +80,10 @@ def _combine_tables(
     if metadata is required, or by dropping to bare dataframes otherwise.
     """
 
-    if method is None or method in frozenset({"reindex", "take", "copy", "groupby"}):
+    if method is None or method in frozenset({
+            "reindex", "take", "copy", "groupby", "replace", "sort_index",
+            "transpose", "astype", "append", "fillna", "rename"
+    }):
         # method: None - copy, slicing (pandas <1.1)
         src = [other]
     elif method == "merge":
@@ -188,7 +191,7 @@ class TableDataFrame(pd.DataFrame):
         table_info = _combine_tables(self, other, method, **kwargs)
         if table_info is None:
             warn(
-                f"Unable to establish table metadata (units, origin, etc.). Will fall back to pd.DataFrame."
+                "Unable to establish table metadata (units, origin, etc.). Will fall back to pd.DataFrame."
             )
             return pd.DataFrame(self)
         object.__setattr__(self, _TABLE_INFO_FIELD_NAME, table_info)

--- a/pdtable/table_metadata.py
+++ b/pdtable/table_metadata.py
@@ -202,13 +202,6 @@ class ComplementaryTableInfo:
         return [col.unit for col in self.columns.values()]
 
     @property
-    def unit_map(self) -> Dict[str, str]:
-        return {
-            col_name: col_metadata.unit 
-            for col_name, col_metadata in self.columns.items()
-        }
-
-    @property
     def name(self) -> str:
         return self.metadata.name
     

--- a/pdtable/table_metadata.py
+++ b/pdtable/table_metadata.py
@@ -10,6 +10,10 @@ class InvalidNamingError(Exception):
     pass
 
 
+class ColumnUnitException(Exception):
+    pass
+
+
 @dataclass
 class TableMetadata:
     """
@@ -106,12 +110,12 @@ class ColumnMetadata:
         context_text = " in " + context if context else ""
         if base_unit in _units_special:
             if not base_unit == self.unit:
-                raise Exception(
+                raise ColumnUnitException(
                     f"Column '{col_name}' unit {self.unit} not equal to {base_unit} expected "
                     f"from data type {dtype}{context_text}"
                 )
         elif self.unit in _units_special:
-            raise Exception(
+            raise ColumnUnitException(
                 f"Column '{col_name}' special unit {self.unit} not applicable for "
                 f"data type {dtype}{context_text}"
             )

--- a/pdtable/test/io/test_read_csv_fixer.py
+++ b/pdtable/test/io/test_read_csv_fixer.py
@@ -336,7 +336,8 @@ class TestNotStrictTypes:
         """
         with open(not_strict_input_file_path, "r") as fh:
             block_iterator = read_csv(fh, fixer=StrictTypesFixer())
-            exc_msg = 'Column unit m not equal to text expected from data type object'
+            exc_msg = \
+                "Column 'height' unit m not equal to text expected from data type object"
 
             with pytest.raises(
                     expected_exception=Exception,

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -1,3 +1,4 @@
+import sys
 from textwrap import dedent
 import warnings
 
@@ -414,6 +415,10 @@ class TestFinalize:
 
         assert isinstance(table_data_frame_new_type['B'].iloc[0], np.float64)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="test passes only with python 3.8 or newer"
+    )
     def test_astype_not_allowed_type(self, table_data_frame: frame.TableDataFrame) -> None:
         with pytest.raises(ColumnUnitException):
             table_data_frame.astype({'B': str})
@@ -440,6 +445,10 @@ class TestFinalize:
             table_data_frame_new_type.fillna(123)
             assert len(w) == 0
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="test passes only with python 3.8 or newer"
+    )
     def test_fillna_not_allowed_type(self, table_data_frame: frame.TableDataFrame) -> None:
         table_data_frame_new_type = table_data_frame.astype({'B': float})
         table_data_frame_new_type.iloc[0, 1] = np.nan
@@ -491,6 +500,10 @@ class TestFinalize:
             ('C', '2'): 'text'
         } == unstacked_col_name_to_unit
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="test passes only with python 3.8 or newer"
+    )
     def test_melt(self, table_data_frame: frame.TableDataFrame) -> None:
         """
         Test check how units of a table data frame change after unstacking.

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 
 from .. import Table, frame
 from ..proxy import Column
-from ..table_metadata import ColumnFormat
+from ..table_metadata import ColumnFormat, ColumnUnitException
 from .conftest import HAS_PYARROW
 
 
@@ -357,3 +358,109 @@ def test_unit_map_with_different_order_than_columns(tmpdir):
     )
     assert {'column_text': 'text', 'column_deg': 'deg'} == \
         dict(zip(table.columns, frame.get_table_info(df=table).units))
+
+
+@pytest.fixture
+def table_data_frame() -> frame.TableDataFrame:
+    data_frame = pd.DataFrame.from_dict({
+        'A': ['b', 'c', 'a', 'd', 'e'],
+        'B': [1, 2, 3, 4, 5],
+        'C': [True, False, True, False, True]
+    })
+    return frame.make_table_dataframe(
+        data_frame,
+        name='test',
+        destinations='abc',
+        unit_map={
+            'A': 'text',
+            'B': 'kg',
+            'C': 'onoff'
+        }
+    )
+
+
+class TestFinalize:
+    def test_replace_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame.replace('a', 'z')
+            assert len(w) == 0
+
+    def test_replace_not_allowed_unit(self, table_data_frame: frame.TableDataFrame) -> None:
+        with pytest.raises(ColumnUnitException):
+            table_data_frame.replace(True, 'a')
+
+    def test_sort_index_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        table_data_frame.set_index('A', inplace=True)
+
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame.sort_index()
+            assert len(w) == 0
+
+    def test_transpose_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        """
+        Columns metadata should be empty after transpose, 
+        since after transposing, we end up with completely new set of columns.
+        """
+        transposed = table_data_frame.transpose()
+        table_data = object.__getattribute__(transposed, frame._TABLE_INFO_FIELD_NAME)
+        assert ['text'] * len(table_data_frame.index) == table_data.units
+
+    def test_astype_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        assert isinstance(table_data_frame['B'].iloc[0], np.int64)
+        
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame_new_type = table_data_frame.astype({'B': float})
+            assert len(w) == 0
+
+        assert isinstance(table_data_frame_new_type['B'].iloc[0], np.float64)
+
+    def test_astype_not_allowed_type(self, table_data_frame: frame.TableDataFrame) -> None:
+        with pytest.raises(ColumnUnitException):
+            table_data_frame.astype({'B': str})
+            
+    def test_append_with_loc_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        """
+        append is executed under the hood while adding a row using loc method.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame.loc[999] = {'A': 'y', 'B': 1, 'C': True}
+            assert len(w) == 0
+        
+        assert 6 == table_data_frame.shape[0]
+
+    def test_append_with_loc_not_allowed_type(self, table_data_frame: frame.TableDataFrame) -> None:
+        with pytest.raises(ColumnUnitException):
+            table_data_frame.loc[999] = {'A': 'y', 'B': 1, 'C': 'no'}
+
+    def test_fillna_ok(self, table_data_frame: frame.TableDataFrame) -> None:
+        table_data_frame_new_type = table_data_frame.astype({'B': float})
+        table_data_frame_new_type.iloc[0, 1] = np.nan
+        
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame_new_type.fillna(123)
+            assert len(w) == 0
+
+    def test_fillna_not_allowed_type(self, table_data_frame: frame.TableDataFrame) -> None:
+        table_data_frame_new_type = table_data_frame.astype({'B': float})
+        table_data_frame_new_type.iloc[0, 1] = np.nan
+        
+        with pytest.raises(ColumnUnitException):
+            table_data_frame_new_type.fillna('123')
+            
+    def test_rename_columns(self, table_data_frame: frame.TableDataFrame) -> None:
+        """
+        Renaming columns is not suported. It can mess with current units settings.
+        """
+        with pytest.raises(ColumnUnitException):
+            table_data_frame.rename(columns={"A": "B", "B": "C", "C": "A"})
+
+    def test_rename_index(self, table_data_frame: frame.TableDataFrame) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            table_data_frame.rename(index={1: 'a', 2: 'b'})
+            assert len(w) == 0
+
+    def test_unstack():
+        pass  # TODO
+    
+    def test_melt():
+        pass  # TODO

--- a/pdtable/test/test_pdtable.py
+++ b/pdtable/test/test_pdtable.py
@@ -459,8 +459,54 @@ class TestFinalize:
             table_data_frame.rename(index={1: 'a', 2: 'b'})
             assert len(w) == 0
 
-    def test_unstack():
-        pass  # TODO
-    
-    def test_melt():
-        pass  # TODO
+    def test_unstack(self, table_data_frame: frame.TableDataFrame) -> None:
+        """
+        Test check how units of a table data frame change after unstacking.
+        """
+        multi_index = pd.MultiIndex.from_tuples([
+            ("a","1"), 
+            ("a","2"),
+            ("b","1"),
+            ("c","1"),
+            ("c","2")
+        ])
+        table_data_frame.set_index(multi_index, inplace=True)
+        
+        with warnings.catch_warnings(record=True) as w:
+            unstacked_table_data_frame = table_data_frame.unstack()
+            assert len(w) == 0
+
+        unstacked_col_name_to_unit = {
+            name: col.unit for name, col in object.__getattribute__(
+                unstacked_table_data_frame,
+                frame._TABLE_INFO_FIELD_NAME
+            ).columns.items()
+        }
+        assert {
+            ('A', '1'): 'text',
+            ('A', '2'): 'text',
+            ('B', '1'): '-',
+            ('B', '2'): '-',
+            ('C', '1'): 'text',
+            ('C', '2'): 'text'
+        } == unstacked_col_name_to_unit
+
+    def test_melt(self, table_data_frame: frame.TableDataFrame) -> None:
+        """
+        Test check how units of a table data frame change after unstacking.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            melted_table_data_frame = table_data_frame.melt(id_vars=['A'], value_vars=['B', 'C'])
+            assert len(w) == 0
+        
+        melted_col_name_to_unit = {
+            name: col.unit for name, col in object.__getattribute__(
+                melted_table_data_frame,
+                frame._TABLE_INFO_FIELD_NAME
+            ).columns.items()
+        }
+        assert {
+            'A': 'text',
+            'variable': 'text',
+            'value': 'text'
+        } == melted_col_name_to_unit


### PR DESCRIPTION
- `check_dtype` raises custom `ColumnUnitException` with a column name in the error message.
- Verification of `_combine_tables` method for more pandas methods. Verification has form of unit tests and all the tested methods were added to the set with default behavior while creating `ComplementaryTableInfo`. It leads to not showing not necessary warnings.